### PR TITLE
Fix Sending First Start Data To MainActivity

### DIFF
--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashActivity.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashActivity.java
@@ -12,9 +12,16 @@ public class RNBootSplashActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
 
     try {
-      startActivity(new Intent(this, Class.forName(getApplicationContext()
-          .getPackageName() + ".MainActivity")));
+      Intent intent = new Intent(this, Class.forName(getApplicationContext()
+        .getPackageName() + ".MainActivity"));
 
+      // Pass along FCM messages/notifications etc.
+      Bundle extras = getIntent().getExtras();
+      if (extras != null) {
+          intent.putExtras(extras);
+      }
+      
+      startActivity(intent);
       finish();
     } catch (ClassNotFoundException e) {
       e.printStackTrace();


### PR DESCRIPTION
If you are trying to use react native firebase notifications you cant use 
```
const notificationOpen: NotificationOpen = await firebase.notifications().getInitialNotification();
    if (notificationOpen) {
        // App was opened by a notification
        // Get the action triggered by the notification being opened
        const action = notificationOpen.action;
        // Get information about the notification that was opened
        const notification: Notification = notificationOpen.notification;
   }
```

because splash activity start on first load and it doesnt send the data to MainActivity.