### PR TITLE
fix(android): get the main application id without suffix

### DIFF
--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashActivity.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashActivity.java
@@ -13,7 +13,7 @@ public class RNBootSplashActivity extends AppCompatActivity {
 
     try {
       Intent intent = new Intent(this, Class.forName(getApplicationContext()
-        .getPackageName() + ".MainActivity"));
+        .getClass().getPackage().getName() + ".MainActivity"));
 
       // Pass along FCM messages/notifications etc.
       Bundle extras = getIntent().getExtras();


### PR DESCRIPTION
current implementation will return the application id with suffix, which is not correct, because `MainActivity` belong to the main package id

current implementation:
```
nl.elements.app.debug.MainActivity
```

correct implementation.
```
nl.elements.app.MainActivity
```