### PR TITLE
Explain the need to export MainActivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ If you want to correctly handle [deep linking](https://developer.android.com/tra
       android:label="@string/app_name"
       android:windowSoftInputMode="adjustResize"
       android:exported="true"
-      android:launchMode="singleTask" /> <!-- set MainActivity android:launchMode to "singleTask" -->
+      android:launchMode="singleTask" /> <!-- set MainActivity android:launchMode to "singleTask" and add android:exported="true" -->
 
     <activity
       android:name="com.zoontek.rnbootsplash.RNBootSplashActivity"


### PR DESCRIPTION
RN projects do not have `android:exported="true"` by default

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zoontek/react-native-bootsplash/45)
<!-- Reviewable:end -->
