### PR TITLE
Expose a way to reset the boot splash and show again in Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ public class MainActivity extends ReactActivity {
     super.onCreate(savedInstanceState);
     RNBootSplash.show(R.drawable.bootsplash, MainActivity.this); // <- display the "bootsplash" xml view over our MainActivity
   }
+
+  @Override
+  protected void onResume() {
+    RNBootSplash.reset(); // <- reset to allow showing the bootsplash again if desired (not required)
+    super.onResume();
+  }
 ```
 
 As Android will not create our main activity before launching the app, we need to display a different activity at start, then switch to our main one.

--- a/README.md
+++ b/README.md
@@ -157,9 +157,10 @@ public class MainActivity extends ReactActivity {
   }
 
   @Override
-  protected void onResume() {
+  protected void onPause() {
     RNBootSplash.reset(); // <- reset to allow showing the bootsplash again if desired (not required)
-    super.onResume();
+    RNBootSplash.show(R.drawable.bootsplash, MainActivity.this); // <- show it again
+    super.onPause();
   }
 ```
 

--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplash.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplash.java
@@ -9,10 +9,10 @@ import androidx.annotation.NonNull;
 
 public class RNBootSplash {
 
-  private static boolean showHasRunOnce = false;
+  private static boolean showHasRun = false;
 
   public static void show(final int drawableResId, @NonNull final Activity activity) {
-    if (showHasRunOnce) return;
+    if (showHasRun) return;
 
     activity.runOnUiThread(new Runnable() {
       @Override
@@ -29,8 +29,12 @@ public class RNBootSplash {
         layout.addView(view, params);
 
         activity.addContentView(layout, params);
-        showHasRunOnce = true;
+        showHasRun = true;
       }
     });
+  }
+
+  public static void reset() {
+    resetHasRun = false;
   }
 }

--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
@@ -19,7 +19,7 @@ public class RNBootSplashModule extends ReactContextBaseJavaModule implements Li
 
   public static final String MODULE_NAME = "RNBootSplash";
 
-  private boolean hideHasRunOnce = false;
+  private boolean hideHasRun = false;
   private boolean hideOnAppResume = false;
 
   public RNBootSplashModule(ReactApplicationContext reactContext) {
@@ -48,7 +48,7 @@ public class RNBootSplashModule extends ReactContextBaseJavaModule implements Li
 
   @ReactMethod
   public void hide(final Float duration) {
-    if (hideHasRunOnce) return;
+    if (hideHasRun) return;
 
     Activity activity = getReactApplicationContext().getCurrentActivity();
 
@@ -63,7 +63,7 @@ public class RNBootSplashModule extends ReactContextBaseJavaModule implements Li
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        hideHasRunOnce = true;
+        hideHasRun = true;
 
         final ViewGroup parent = (ViewGroup) layout.getParent();
         int roundedDuration = duration.intValue();
@@ -83,6 +83,7 @@ public class RNBootSplashModule extends ReactContextBaseJavaModule implements Li
               public void onAnimationEnd(Animator animation) {
                 super.onAnimationEnd(animation);
                 parent.removeView(layout);
+                hideHasRun = false;
               }
             }).start();
       }


### PR DESCRIPTION
First off, thanks for this awesome boot splash React Native module!

We have a use case where we want to display our splash screen when our app is displayed in "recent apps" on Android and on iOS.  We want to leverage RNBootSplash since we're already using it.  On the iOS side we can call `show` multiple times but on Android there is some code that prevents that.  This is just a simple PR that exposes a way to reset the splash screen on Android that would be super easy for us (and hopefully others) to implement.

What do you all think?