### PR TITLE
Docs : update splash screen image resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Edit the `ios/YourProjectName/AppDelegate.m` file:
   <item>
     <!-- the app logo, centered horizontally and vertically -->
     <bitmap
-      android:src="@mipmap/ic_launcher"
+      android:src="@mipmap/bootsplash_logo"
       android:gravity="center" />
   </item>
 </layer-list>


### PR DESCRIPTION
 Use bootsplash_logo image instead of ic_launcher to fix " App stopped " issue on Android