### PR TITLE
WIP: Added possibility to change Application background after splash hides instead of defining special Activity for Splash

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,15 @@ If you want to correctly handle [deep linking](https://developer.android.com/tra
 </manifest>
 ```
 
+### Change Application Background Color After Splash Screen hides (on Android)
+
+If we pass `MainActivity` into `RNBootSplash.init`, library changes `MainActivity`'s background according to SplashScreen design.
+After Splash Screen hides we want the option to set background that fits the app.
+We want this because when Android shows software keyboard, Application background is visible below for a very brief moment
+and Splash Screen design might be inappropriate here. 
+
+To achieve that, use overloaded `init` call in `Java`: `RNBootSplash.init(R.drawable.bootsplash, YourActivity.this, R.color.your_after_hide_color);` 
+
 ## 🕵️‍♂️ Comparison with [react-native-splash-screen](https://github.com/crazycodeboy/react-native-splash-screen)
 
 - If `react-native-splash-screen` encourages you to display an image over your application, `react-native-bootsplash` way-to-go is to design your launch screen using platforms tools ([Xcode layout editor](https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/AutolayoutPG/) and [Android drawable resource](https://developer.android.com/guide/topics/resources/drawable-resource)).

--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplash.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplash.java
@@ -12,6 +12,7 @@ import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import com.facebook.react.bridge.UiThreadUtil;
 
@@ -20,12 +21,27 @@ public class RNBootSplash {
   private static boolean mInitialized = false;
   private static int mDrawableResId = -1;
   private static boolean mIsVisible = false;
+  private static int afterHideColor = 0;
 
   public static void init(final int drawableResId, @NonNull final Activity activity) {
     if (!mInitialized) {
       mDrawableResId = drawableResId;
       mInitialized = true;
       RNBootSplash.show(activity, 0.0f);
+    }
+  }
+
+  public static void init(final int drawableResId, @NonNull final Activity activity, int afterHideColorId) {
+    if (!mInitialized) {
+      RNBootSplash.afterHideColor = ContextCompat.getColor(activity, afterHideColorId);
+      RNBootSplash.init(drawableResId, activity);
+    }
+  }
+
+  private static void changeApplicationBackgroundIfNeeded(@NonNull final Activity activity) {
+    if (afterHideColor != 0) {
+      final View root = activity.findViewById(android.R.id.content).getRootView();
+      root.setBackgroundColor(afterHideColor);
     }
   }
 
@@ -89,6 +105,7 @@ public class RNBootSplash {
 
         if (roundedDuration <= 0) {
           parent.removeView(layout);
+          changeApplicationBackgroundIfNeeded(activity);
         } else {
           layout
               .animate()
@@ -101,6 +118,7 @@ public class RNBootSplash {
                   super.onAnimationEnd(animation);
                   if (parent != null) {
                     parent.removeView(layout);
+                    changeApplicationBackgroundIfNeeded(activity);
                   }
                 }
               }).start();


### PR DESCRIPTION
When we were applying `react-native-bootsplash` to our project, we didn't want to add new activity just for Boot Splash because creating and destroying Activity for just a few seconds seems too heavy to us.

This however raised an issue in our app: `[Android] - Screen with App logo is shown for a moment after showing keyboard in the background`

Our Splash Screen:
![splash](https://user-images.githubusercontent.com/14107317/77528985-28140200-6e8f-11ea-8594-c97efcb1877e.png)

When showing keyboard, Splash Screen is visible in the background:
![2](https://user-images.githubusercontent.com/14107317/77529084-47129400-6e8f-11ea-98e3-17fb381bf41d.png) 
![3](https://user-images.githubusercontent.com/14107317/77529090-47ab2a80-6e8f-11ea-9714-7c1ccdb6ac15.png) 

This was caused by Android behaviour: https://github.com/facebook/react-native/issues/17800

Given that `react-native-bootsplash` now changes background of the `MainActivity` instead of `com.zoontek.rnbootsplash.RNBootSplashActivity`, we needed to add possibility to change the background programatically after `hide` so we would solve our issue and maintain current functionality of two different styles - Main | Boot.

I overloaded `init` function with Colour ID parameter which is then set to background after `react-native-bootsplash` calls `hide`. Then I've set splash background directly to `MainActivity` in `styles.xml`:
```
<!-- Base application theme. -->
<style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
  ...
  <!--for splash screen-->
  <item name="android:windowBackground">@drawable/splash</item>
</style>
```

This solved the issue:

![5](https://user-images.githubusercontent.com/14107317/77529470-f64f6b00-6e8f-11ea-892a-4ce5b4b76358.png)
![6](https://user-images.githubusercontent.com/14107317/77529472-f7809800-6e8f-11ea-9b83-369a658fd4a6.png)

This is a WIP proposal of refactor of the library to have the different style option in `init` method instead of need to create another activity.

@zoontek If you would agree with this change I would add another `init` overloaded methods for `Drawable` and anything else that would be required.
