### PR TITLE
Add React-Native command plugin: "generate-bootsplash"

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,20 +89,21 @@ public class MainApplication extends Application implements ReactApplication {
 
 ## Setup
 
-### Assets generation
+### React-Native Plugin
 
-**NEW** React-Native BootSplash provides a react-native plugin to allow contextual creation of your bootsplash
+#### Usage
+
+**NEW** React-Native BootSplash provides a react-native plugin `react-native generate-bootsplash` to allow contextual creation of your bootsplash\$ react-native generate-bootsplash --iconPath=myicon.png
 
 ```bash
-# Noninteractive deployment
-$ react-native init-bootsplash --iconPath=myicon.png
+react-native generate-bootsplash --iconPath=myIcon.png --addToXcode
 ```
 
 The plugin takes arguments:
 
 ```
-$ react-native init-bootsplash --help
-react-native init-bootsplash
+$ react-native generate-bootsplash --help
+react-native generate-bootsplash
 
 Initialize bootsplash with arguments or interactively
 
@@ -111,10 +112,13 @@ Options:
   --iconPath [path]          Path to icon to build the bootsplash screen around (leave blank for interactive) (default: "")
   --backgroundColor <color>  Background color to wrap around the icon (default: "#fff")
   --iconWidth <width>        Width of the icon in background image (default: 100)
+  --addToXcode               Add the storyboard file to Xcode and make it default launch screen
   -h, --help                 output usage information
 ```
 
 Note that the only argument that is required for noninteractive setup is `iconPath` - the system will take care of everything else. Leaving `iconPath` blank will revert to the older, interactive setup process.
+
+#### Legacy CLI
 
 We also provide a yarn-based **CLI** to resize assets, create the Android Drawable XML file and the iOS Storyboard file automatically ✨.
 
@@ -122,8 +126,6 @@ We also provide a yarn-based **CLI** to resize assets, create the Android Drawab
 $ npx generate-bootsplash
 # --- or ---
 $ yarn generate-bootsplash
-# -- or: note this uses no arguments
-$ react-native init-bootsplash
 ```
 
 ![](https://raw.githubusercontent.com/zoontek/react-native-bootsplash/master/scripts/screenshot.png?raw=true)

--- a/README.md
+++ b/README.md
@@ -91,12 +91,39 @@ public class MainApplication extends Application implements ReactApplication {
 
 ### Assets generation
 
-In order to speed up the setup, we provide a **CLI** to resize assets, create the Android Drawable XML file and the iOS Storyboard file automatically ✨.
+**NEW** React-Native BootSplash provides a react-native plugin to allow contextual creation of your bootsplash
+
+```bash
+# Noninteractive deployment
+$ react-native init-bootsplash --iconPath=myicon.png
+```
+
+The plugin takes arguments:
+
+```
+$ react-native init-bootsplash --help
+react-native init-bootsplash
+
+Initialize bootsplash with arguments or interactively
+
+Options:
+  --assetsPath <path>        Path for storing assets (default: "./assets")
+  --iconPath [path]          Path to icon to build the bootsplash screen around (leave blank for interactive) (default: "")
+  --backgroundColor <color>  Background color to wrap around the icon (default: "#fff")
+  --iconWidth <width>        Width of the icon in background image (default: 100)
+  -h, --help                 output usage information
+```
+
+Note that the only argument that is required for noninteractive setup is `iconPath` - the system will take care of everything else. Leaving `iconPath` blank will revert to the older, interactive setup process.
+
+We also provide a yarn-based **CLI** to resize assets, create the Android Drawable XML file and the iOS Storyboard file automatically ✨.
 
 ```bash
 $ npx generate-bootsplash
 # --- or ---
 $ yarn generate-bootsplash
+# -- or: note this uses no arguments
+$ react-native init-bootsplash
 ```
 
 ![](https://raw.githubusercontent.com/zoontek/react-native-bootsplash/master/scripts/screenshot.png?raw=true)

--- a/README.md
+++ b/README.md
@@ -181,12 +181,6 @@ Edit the `ios/YourProjectName/AppDelegate.m` file:
 }
 ```
 
-Set the `BootSplash.storyboard` as launch screen file:
-
-| Drag and drop the file                                                                                  | Create folder reference                                                                                 | Set as Launch Screen File                                                                               |
-| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| ![](https://raw.githubusercontent.com/zoontek/react-native-bootsplash/master/docs/xcode-1.png?raw=true) | ![](https://raw.githubusercontent.com/zoontek/react-native-bootsplash/master/docs/xcode-2.png?raw=true) | ![](https://raw.githubusercontent.com/zoontek/react-native-bootsplash/master/docs/xcode-3.png?raw=true) |
-
 ### Android
 
 1. Edit the `android/app/src/main/java/com/yourprojectname/MainActivity.java` file:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ public class MainApplication extends Application implements ReactApplication {
 
 #### Usage
 
-**NEW** React-Native BootSplash provides a react-native plugin `react-native generate-bootsplash` to allow contextual creation of your bootsplash\$ react-native generate-bootsplash --iconPath=myicon.png
+React-Native BootSplash provides a react-native plugin `react-native generate-bootsplash` to allow contextual creation of your bootsplash.
 
 ```bash
 react-native generate-bootsplash --iconPath=myIcon.png --addToXcode
@@ -103,7 +103,7 @@ The plugin takes arguments:
 
 ```
 $ react-native generate-bootsplash --help
-react-native generate-bootsplash
+react-native generate-bootsplash [iconPath]
 
 Initialize bootsplash with arguments or interactively
 
@@ -114,6 +114,12 @@ Options:
   --iconWidth <width>        Width of the icon in background image (default: 100)
   --addToXcode               Add the storyboard file to Xcode and make it default launch screen
   -h, --help                 output usage information
+```
+
+For best results, specify the icon and use the `addToXcode` directive:
+
+```bash
+$ react-native generate-bootsplash /path/to/my/icon --addToXcode
 ```
 
 Note that the only argument that is required for noninteractive setup is `iconPath` - the system will take care of everything else. Leaving `iconPath` blank will revert to an interactive setup process:

--- a/README.md
+++ b/README.md
@@ -116,17 +116,7 @@ Options:
   -h, --help                 output usage information
 ```
 
-Note that the only argument that is required for noninteractive setup is `iconPath` - the system will take care of everything else. Leaving `iconPath` blank will revert to the older, interactive setup process.
-
-#### Legacy CLI
-
-We also provide a yarn-based **CLI** to resize assets, create the Android Drawable XML file and the iOS Storyboard file automatically ✨.
-
-```bash
-$ npx generate-bootsplash
-# --- or ---
-$ yarn generate-bootsplash
-```
+Note that the only argument that is required for noninteractive setup is `iconPath` - the system will take care of everything else. Leaving `iconPath` blank will revert to an interactive setup process:
 
 ![](https://raw.githubusercontent.com/zoontek/react-native-bootsplash/master/scripts/screenshot.png?raw=true)
 

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -68,9 +68,9 @@ const getStoryboard = ({
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <imageView autoresizesSubviews="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="${xcassetName}" translatesAutoresizingMaskIntoConstraints="NO" id="3lX-Ut-9ad">
-                                <rect key="frame" x="${(414 - width) /
-                                  2}" y="${(896 - height) /
-  2}" width="${width}" height="${height}"/>
+                                <rect key="frame" x="${(414 - width) / 2}" y="${
+  (896 - height) / 2
+}" width="${width}" height="${height}"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <accessibilityTraits key="traits" image="YES" notEnabled="YES"/>
                                 </accessibility>
@@ -113,15 +113,15 @@ const log = (text, dim = false) => {
   console.log(dim ? chalk.dim(text) : text);
 };
 
-const ensureDir = dir => {
+const ensureDir = (dir) => {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir);
   }
 };
 
-const isValidHexadecimal = value => /^#?([0-9A-F]{3}){1,2}$/i.test(value);
+const isValidHexadecimal = (value) => /^#?([0-9A-F]{3}){1,2}$/i.test(value);
 
-const toFullHexadecimal = hex => {
+const toFullHexadecimal = (hex) => {
   const prefixed = hex[0] === "#" ? hex : `#${hex}`;
   const up = prefixed.toUpperCase();
 
@@ -130,12 +130,12 @@ const toFullHexadecimal = hex => {
     : up;
 };
 
-const hexadecimalToAppleColor = hex => ({
+const hexadecimalToAppleColor = (hex) => ({
   r: (parseInt(hex[1] + hex[2], 16) / 255).toPrecision(15),
   g: (parseInt(hex[3] + hex[4], 16) / 255).toPrecision(15),
   b: (parseInt(hex[5] + hex[6], 16) / 255).toPrecision(15),
 });
-const getProjectName = projectPath => {
+const getProjectName = (projectPath) => {
   try {
     const appJsonPath = path.join(projectPath, "app.json");
     const appJson = fs.readFileSync(appJsonPath, "utf-8");
@@ -170,7 +170,7 @@ async function generate({
   const fullHexadecimal = toFullHexadecimal(backgroundColor);
   const appleColors = hexadecimalToAppleColor(fullHexadecimal);
 
-  const h = size =>
+  const h = (size) =>
     Math.ceil(size * (image.bitmap.height / image.bitmap.width));
 
   const w15 = w1 * 1.5;
@@ -307,6 +307,7 @@ async function generate({
   log(
     `✅  Done! Thanks for using ${chalk.underline("react-native-bootsplash")}.`,
   );
+  return projectPath;
 }
 
 const addToProject = (root = process.cwd()) => {
@@ -322,10 +323,10 @@ const addToProject = (root = process.cwd()) => {
   }
   const projectsPaths = sync(
     join(iosPath, "**", "*.xcodeproj", "*.pbxproj"),
-  ).filter(path => !path.includes("Pods"));
-  projectsPaths.forEach(path => {
+  ).filter((path) => !path.includes("Pods"));
+  projectsPaths.forEach((path) => {
     const project = Xcode.project(path);
-    project.parse(err => {
+    project.parse((err) => {
       const fp = project.getFirstProject();
       const dir = basename(dirname(bootSplashPath));
       const file = project.addResourceFile(
@@ -334,7 +335,6 @@ const addToProject = (root = process.cwd()) => {
         fp,
       );
       if (!file) return;
-      console.log("COndinuting with file obj", file);
       file.uuid = project.generateUuid();
       const nts = project.pbxNativeTargetSection();
       for (var key in nts) {
@@ -347,12 +347,11 @@ const addToProject = (root = process.cwd()) => {
       //Look for the storyboard
       const out = project.writeSync();
       writeFileSync(path, out);
-      console.log("I wrote out", path);
     });
   });
 
   const plistPaths = sync(join(iosPath, "**", "Info.plist"));
-  plistPaths.forEach(path => {
+  plistPaths.forEach((path) => {
     const xml = readFileSync(path, { encoding: "utf8" });
     const plist = Plist.parse(xml);
     plist.UILaunchStoryboardName = "BootSplash.storyboard";

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const path = require("path");
+const fs = require("fs");
+const chalk = require("chalk");
+const jimp = require("jimp");
+
+let projectName;
+
+const logoFileName = "bootsplash_logo";
+const xcassetName = "BootSplashLogo";
+const androidColorRegex = /<color name="bootsplash_background">#\w+<\/color>/g;
+
+const ContentsJson = `{
+  "images": [
+    {
+      "idiom": "universal",
+      "filename": "${logoFileName}.png",
+      "scale": "1x"
+    },
+    {
+      "idiom": "universal",
+      "filename": "${logoFileName}@2x.png",
+      "scale": "2x"
+    },
+    {
+      "idiom": "universal",
+      "filename": "${logoFileName}@3x.png",
+      "scale": "3x"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}
+`;
+
+const getStoryboard = ({
+  height,
+  width,
+  r,
+  g,
+  b,
+}) => `<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Dtp-p8-LvN">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="Fnd-62-7zz">
+            <objects>
+                <viewController id="Dtp-p8-LvN" sceneMemberID="viewController">
+                    <view key="view" autoresizesSubviews="NO" userInteractionEnabled="NO" contentMode="scaleToFill" id="guO-oA-Nhw">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <imageView autoresizesSubviews="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="${xcassetName}" translatesAutoresizingMaskIntoConstraints="NO" id="3lX-Ut-9ad">
+                                <rect key="frame" x="${(414 - width) /
+                                  2}" y="${(896 - height) /
+  2}" width="${width}" height="${height}"/>
+                                <accessibility key="accessibilityConfiguration">
+                                    <accessibilityTraits key="traits" image="YES" notEnabled="YES"/>
+                                </accessibility>
+                            </imageView>
+                        </subviews>
+                        <color key="backgroundColor" red="${r}" green="${g}" blue="${b}" alpha="1" colorSpace="calibratedRGB"/>
+                        <accessibility key="accessibilityConfiguration">
+                            <accessibilityTraits key="traits" notEnabled="YES"/>
+                        </accessibility>
+                        <constraints>
+                            <constraint firstItem="3lX-Ut-9ad" firstAttribute="centerX" secondItem="eg9-kz-Dhh" secondAttribute="centerX" id="Fh9-Fy-1nT"/>
+                            <constraint firstItem="3lX-Ut-9ad" firstAttribute="centerY" secondItem="guO-oA-Nhw" secondAttribute="centerY" id="nvB-Ic-PnI"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="eg9-kz-Dhh"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Lvb-Jr-bCV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="0.0" y="0.0"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="${xcassetName}" width="${width}" height="${height}"/>
+    </resources>
+</document>
+`;
+
+const drawableXml = `<?xml version="1.0" encoding="utf-8"?>
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" android:opacity="opaque">
+    <item android:drawable="@color/bootsplash_background" />
+
+    <item>
+        <bitmap android:src="@mipmap/${logoFileName}" android:gravity="center" />
+    </item>
+</layer-list>
+`;
+
+const log = (text, dim = false) => {
+  console.log(dim ? chalk.dim(text) : text);
+};
+
+const ensureDir = dir => {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir);
+  }
+};
+
+const isValidHexadecimal = value => /^#?([0-9A-F]{3}){1,2}$/i.test(value);
+
+const toFullHexadecimal = hex => {
+  const prefixed = hex[0] === "#" ? hex : `#${hex}`;
+  const up = prefixed.toUpperCase();
+
+  return up.length === 4
+    ? "#" + up[1] + up[1] + up[2] + up[2] + up[3] + up[3]
+    : up;
+};
+
+const hexadecimalToAppleColor = hex => ({
+  r: (parseInt(hex[1] + hex[2], 16) / 255).toPrecision(15),
+  g: (parseInt(hex[3] + hex[4], 16) / 255).toPrecision(15),
+  b: (parseInt(hex[5] + hex[6], 16) / 255).toPrecision(15),
+});
+const getProjectName = projectPath => {
+  try {
+    const appJsonPath = path.join(projectPath, "app.json");
+    const appJson = fs.readFileSync(appJsonPath, "utf-8");
+    const { name } = JSON.parse(appJson);
+
+    if (!name) {
+      throw new Error("Invalid projectPath");
+    }
+
+    return name;
+  } catch (e) {
+    return false;
+  }
+};
+
+async function generate({
+  projectPath,
+  assetsPath,
+  iconPath,
+  backgroundColor,
+  iconWidth: w1,
+  confirmation,
+}) {
+  if (!projectPath || !assetsPath || !iconPath || !w1 || !confirmation) {
+    throw "Missing arguments";
+  }
+  if (!projectName) projectName = getProjectName(projectPath);
+  if (!projectName) throw "No valid project at path " + projectPath;
+  const image = await jimp.read(iconPath);
+  const imageMap = [];
+
+  const fullHexadecimal = toFullHexadecimal(backgroundColor);
+  const appleColors = hexadecimalToAppleColor(fullHexadecimal);
+
+  const h = size =>
+    Math.ceil(size * (image.bitmap.height / image.bitmap.width));
+
+  const w15 = w1 * 1.5;
+  const w2 = w1 * 2;
+  const w3 = w1 * 3;
+  const w4 = w1 * 4;
+
+  const androidResPath = path.join(
+    projectPath,
+    "android",
+    "app",
+    "src",
+    "main",
+    "res",
+  );
+
+  if (fs.existsSync(androidResPath)) {
+    const fileName = `${logoFileName}.png`;
+
+    imageMap.push(
+      [path.join(androidResPath, "mipmap-mdpi", fileName), [w1, h(w1)]],
+      [path.join(androidResPath, "mipmap-hdpi", fileName), [w15, h(w15)]],
+      [path.join(androidResPath, "mipmap-xhdpi", fileName), [w2, h(w2)]],
+      [path.join(androidResPath, "mipmap-xxhdpi", fileName), [w3, h(w3)]],
+      [path.join(androidResPath, "mipmap-xxxhdpi", fileName), [w4, h(w4)]],
+    );
+  } else {
+    log(`No ${androidResPath} directory found. Skipping android generation…`);
+  }
+
+  const iosProjectPath = path.join(projectPath, "ios", projectName);
+  const iosImagesPath = path.join(iosProjectPath, "Images.xcassets");
+
+  if (fs.existsSync(iosImagesPath)) {
+    const iosImageSetPath = path.join(iosImagesPath, `${xcassetName}.imageset`);
+    ensureDir(iosImageSetPath);
+
+    fs.writeFileSync(
+      path.join(iosImageSetPath, "Contents.json"),
+      ContentsJson,
+      "utf-8",
+    );
+
+    imageMap.push(
+      [path.join(iosImageSetPath, `${logoFileName}.png`), [w1, h(w1)]],
+      [path.join(iosImageSetPath, `${logoFileName}@2x.png`), [w2, h(w2)]],
+      [path.join(iosImageSetPath, `${logoFileName}@3x.png`), [w3, h(w3)]],
+    );
+  } else {
+    log(`No ${iosImagesPath} directory found. Skipping iOS generation…`);
+  }
+
+  imageMap.push(
+    [path.join(assetsPath, logoFileName + ".png"), [w1, h(w1)]],
+    [path.join(assetsPath, logoFileName + "@1,5x.png"), [w15, h(w15)]],
+    [path.join(assetsPath, logoFileName + "@2x.png"), [w2, h(w2)]],
+    [path.join(assetsPath, logoFileName + "@3x.png"), [w3, h(w3)]],
+    [path.join(assetsPath, logoFileName + "@4x.png"), [w4, h(w4)]],
+  );
+
+  log("👍  Looking good! Generating files…");
+
+  await Promise.all(
+    imageMap.map(([path, [width, height]]) =>
+      image
+        .clone()
+        .cover(width, height)
+        .writeAsync(path)
+        .then(() => {
+          log(`✨  ${path} (${width}x${height})`, true);
+        }),
+    ),
+  );
+
+  if (fs.existsSync(iosProjectPath)) {
+    const storyboard = path.join(iosProjectPath, `BootSplash.storyboard`);
+
+    fs.writeFileSync(
+      storyboard,
+      getStoryboard({ height: h(w1), width: w1, ...appleColors }),
+      "utf-8",
+    );
+
+    log(`✨  ${storyboard}`, true);
+  }
+
+  if (fs.existsSync(androidResPath)) {
+    const drawableDir = path.join(androidResPath, "drawable");
+    ensureDir(drawableDir);
+    const drawable = path.join(drawableDir, "bootsplash.xml");
+    fs.writeFileSync(drawable, drawableXml, "utf-8");
+
+    log(`✨  ${drawable}`, true);
+
+    const valuesDir = path.join(androidResPath, "values");
+    ensureDir(valuesDir);
+    const colors = path.join(valuesDir, "colors.xml");
+
+    if (fs.existsSync(colors)) {
+      const content = fs.readFileSync(colors, "utf-8");
+
+      if (content.match(androidColorRegex)) {
+        fs.writeFileSync(
+          colors,
+          content.replace(
+            androidColorRegex,
+            `<color name="bootsplash_background">${fullHexadecimal}</color>`,
+          ),
+          "utf-8",
+        );
+      } else {
+        fs.writeFileSync(
+          colors,
+          content.replace(
+            /<\/resources>/g,
+            `    <color name="bootsplash_background">${fullHexadecimal}</color>\n</resources>`,
+          ),
+          "utf-8",
+        );
+      }
+
+      log(`✏️   Editing ${colors}`, true);
+    } else {
+      fs.writeFileSync(
+        colors,
+        `<resources>\n    <color name="bootsplash_background">${fullHexadecimal}</color>\n</resources>\n`,
+        "utf-8",
+      );
+
+      log(`✨  ${colors}`, true);
+    }
+  }
+
+  log(
+    `✅  Done! Thanks for using ${chalk.underline("react-native-bootsplash")}.`,
+  );
+}
+module.exports = { generate };

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -313,7 +313,7 @@ async function generate({
 const addToProject = (root = process.cwd()) => {
   //Look for pbxproject
   const iosPath = join(root, "ios");
-  const bootSplashes = sync(join(iosPath, "**", "Bootsplash.storyboard"));
+  const bootSplashes = sync(join(iosPath, "**", "BootSplash.storyboard"));
   const bootSplashPath = bootSplashes[0];
   if (!bootSplashPath) {
     console.error(

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -6,6 +6,11 @@ const path = require("path");
 const fs = require("fs");
 const chalk = require("chalk");
 const jimp = require("jimp");
+const { join, dirname, basename } = path;
+const { readFileSync, writeFileSync } = fs;
+const Xcode = require("@raydeck/xcode");
+const Plist = require("plist");
+const { sync } = require("glob");
 
 let projectName;
 
@@ -303,4 +308,56 @@ async function generate({
     `✅  Done! Thanks for using ${chalk.underline("react-native-bootsplash")}.`,
   );
 }
-module.exports = { generate };
+
+const addToProject = (root = process.cwd()) => {
+  //Look for pbxproject
+  const iosPath = join(root, "ios");
+  const bootSplashes = sync(join(iosPath, "**", "Bootsplash.storyboard"));
+  const bootSplashPath = bootSplashes[0];
+  if (!bootSplashPath) {
+    console.error(
+      "Could not find BootSplash.storyboard - try running: yarn generate-bootsplash",
+    );
+    return;
+  }
+  const projectsPaths = sync(
+    join(iosPath, "**", "*.xcodeproj", "*.pbxproj"),
+  ).filter(path => !path.includes("Pods"));
+  projectsPaths.forEach(path => {
+    const project = Xcode.project(path);
+    project.parse(err => {
+      const fp = project.getFirstProject();
+      const dir = basename(dirname(bootSplashPath));
+      const file = project.addResourceFile(
+        join(dir, "BootSplash.storyboard"),
+        null,
+        fp,
+      );
+      if (!file) return;
+      console.log("COndinuting with file obj", file);
+      file.uuid = project.generateUuid();
+      const nts = project.pbxNativeTargetSection();
+      for (var key in nts) {
+        if (key.endsWith("_comment")) continue;
+        const target = project.pbxTargetByName(nts[key].name);
+        file.target = key;
+        project.addToPbxBuildFileSection(file); // PBXBuildFile
+        project.addToPbxResourcesBuildPhase(file);
+      }
+      //Look for the storyboard
+      const out = project.writeSync();
+      writeFileSync(path, out);
+      console.log("I wrote out", path);
+    });
+  });
+
+  const plistPaths = sync(join(iosPath, "**", "Info.plist"));
+  plistPaths.forEach(path => {
+    const xml = readFileSync(path, { encoding: "utf8" });
+    const plist = Plist.parse(xml);
+    plist.UILaunchStoryboardName = "BootSplash.storyboard";
+    const out = Plist.build(plist);
+    writeFileSync(path, out);
+  });
+};
+module.exports = { generate, addToProject };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
   "dependencies": {
     "chalk": "4.0.0",
     "jimp": "0.10.1",
-    "prompts": "2.3.2"
+    "prompts": "2.3.2",
+    "@raydeck/xcode": "2.2.1",
+    "glob": "7.1.6",
+    "plist": "3.0.1"
   },
   "devDependencies": {
     "@babel/core": "7.9.0",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -27,6 +27,7 @@ module.exports = {
         {
           name: "--iconWidth <width>",
           default: 100,
+          parse: arg => parseInt(arg),
           description: "Width of the icon in background image",
         },
       ],
@@ -40,21 +41,13 @@ module.exports = {
             stdio: "inherit",
           });
         } else {
-          console.log("Hello there", {
-            projectPath: ".",
-            assetsPath,
-            iconPath,
-            backgroundColor,
-            iconWidth,
-            confirmation: true,
-          });
           if (!existsSync(assetsPath)) mkdirSync(assetsPath);
           const out = await generate({
             projectPath: ".",
             assetsPath,
             iconPath,
             backgroundColor,
-            iconWidth,
+            iconWidth: iconWidth,
             confirmation: true,
           });
           console.log("Done");

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,4 +1,4 @@
-const { generate } = require("./lib/generate");
+const { generate, addToProject } = require("./lib/generate");
 const { spawnSync } = require("child_process");
 const { join } = require("path");
 const { existsSync, mkdirSync } = require("fs");
@@ -50,7 +50,7 @@ module.exports = {
             iconWidth: iconWidth,
             confirmation: true,
           });
-          console.log("Done");
+          addToProject();
         }
       },
     },

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,63 @@
+const { generate } = require("./lib/generate");
+const { spawnSync } = require("child_process");
+const { join } = require("path");
+module.exports = {
+  commands: [
+    {
+      name: "init-bootsplash",
+      description: "Initialize bootsplash with arguments or interactively",
+      options: [
+        {
+          name: "--assetsPath <path>",
+          description: "Path for storing assets",
+          default: "./assets",
+        },
+        {
+          name: "--iconPath [path]",
+          description:
+            "Path to icon to build the bootsplash screen around (leave blank for interactive)",
+          default: "",
+        },
+        {
+          name: "--backgroundColor <color>",
+          description: "Background color to wrap around the icon",
+          default: "#fff",
+        },
+        {
+          name: "--iconWidth <width>",
+          default: 100,
+          description: "Width of the icon in background image",
+        },
+      ],
+      func: async (
+        _,
+        __,
+        { assetsPath, iconPath, backgroundColor, iconWidth },
+      ) => {
+        if (!iconPath) {
+          spawnSync("node", [join(__dirname, "scripts", "generate.js")], {
+            stdio: "inherit",
+          });
+        } else {
+          console.log("Hello there", {
+            projectPath: ".",
+            assetsPath,
+            iconPath,
+            backgroundColor,
+            iconWidth,
+            confirmation: true,
+          });
+          const out = await generate({
+            projectPath: ".",
+            assetsPath,
+            iconPath,
+            backgroundColor,
+            iconWidth,
+            confirmation: true,
+          });
+          console.log("Done");
+        }
+      },
+    },
+  ],
+};

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,6 +1,7 @@
 const { generate } = require("./lib/generate");
 const { spawnSync } = require("child_process");
 const { join } = require("path");
+const { existsSync, mkdirSync } = require("fs");
 module.exports = {
   commands: [
     {
@@ -47,6 +48,7 @@ module.exports = {
             iconWidth,
             confirmation: true,
           });
+          if (!existsSync(assetsPath)) mkdirSync(assetsPath);
           const out = await generate({
             projectPath: ".",
             assetsPath,

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -5,7 +5,14 @@ const { existsSync, mkdirSync } = require("fs");
 module.exports = {
   commands: [
     {
-      name: "init-bootsplash",
+      name: "add-bootsplash-to-xcode",
+      description: "Add bootsplash launch screen to xcode",
+      func: () => {
+        addToProject();
+      },
+    },
+    {
+      name: "generate-bootsplash",
       description: "Initialize bootsplash with arguments or interactively",
       options: [
         {
@@ -30,11 +37,16 @@ module.exports = {
           parse: arg => parseInt(arg),
           description: "Width of the icon in background image",
         },
+        {
+          name: "--addToXcode",
+          description:
+            "Add the storyboard file to Xcode and make it default launch screen",
+        },
       ],
       func: async (
         _,
         __,
-        { assetsPath, iconPath, backgroundColor, iconWidth },
+        { assetsPath, iconPath, backgroundColor, iconWidth, addToXcode },
       ) => {
         if (!iconPath) {
           spawnSync("node", [join(__dirname, "scripts", "generate.js")], {
@@ -50,7 +62,7 @@ module.exports = {
             iconWidth: iconWidth,
             confirmation: true,
           });
-          addToProject();
+          if (addToXcode) addToProject();
         }
       },
     },

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -129,5 +129,18 @@ const questions = [
 
 prompts(questions)
   .then(generate)
-  .then(addToProject)
+  .then(async (path) => {
+    const { add } = await prompts([
+      {
+        name: "add",
+        type: "confirm",
+        message:
+          "Assets created. Update your ios project to use the new launch storyboard?",
+        default: true,
+      },
+    ]);
+    if (add && path) {
+      return addToProject(path);
+    }
+  })
   .catch((error) => log(chalk.red.bold(error.toString())));

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -6,7 +6,7 @@ const path = require("path");
 const fs = require("fs");
 const chalk = require("chalk");
 const prompts = require("prompts");
-const { generate } = require("../lib/generate");
+const { generate, addToProject } = require("../lib/generate");
 let projectName;
 
 const logoFileName = "bootsplash_logo";
@@ -129,4 +129,5 @@ const questions = [
 
 prompts(questions)
   .then(generate)
+  .then(addToProject)
   .catch((error) => log(chalk.red.bold(error.toString())));

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -5,14 +5,11 @@
 const path = require("path");
 const fs = require("fs");
 const chalk = require("chalk");
-const jimp = require("jimp");
 const prompts = require("prompts");
-
+const { generate } = require("../lib/generate");
 let projectName;
 
 const logoFileName = "bootsplash_logo";
-const xcassetName = "BootSplashLogo";
-const androidColorRegex = /<color name="bootsplash_background">#\w+<\/color>/g;
 
 const initialProjectPath = path.join(
   ".",
@@ -21,121 +18,11 @@ const initialProjectPath = path.join(
     path.resolve(path.join(__dirname, "..", "..", "..")),
   ),
 );
-
-const ContentsJson = `{
-  "images": [
-    {
-      "idiom": "universal",
-      "filename": "${logoFileName}.png",
-      "scale": "1x"
-    },
-    {
-      "idiom": "universal",
-      "filename": "${logoFileName}@2x.png",
-      "scale": "2x"
-    },
-    {
-      "idiom": "universal",
-      "filename": "${logoFileName}@3x.png",
-      "scale": "3x"
-    }
-  ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
-  }
-}
-`;
-
-const getStoryboard = ({ height, width, r, g, b }) => {
-  const x = (414 - width) / 2;
-  const y = (896 - height) / 2;
-
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Dtp-p8-LvN">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
-    <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
-    </dependencies>
-    <scenes>
-        <!--View Controller-->
-        <scene sceneID="Fnd-62-7zz">
-            <objects>
-                <viewController id="Dtp-p8-LvN" sceneMemberID="viewController">
-                    <view key="view" autoresizesSubviews="NO" userInteractionEnabled="NO" contentMode="scaleToFill" id="guO-oA-Nhw">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                        <subviews>
-                            <imageView autoresizesSubviews="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="${xcassetName}" translatesAutoresizingMaskIntoConstraints="NO" id="3lX-Ut-9ad">
-                                <rect key="frame" x="${x}" y="${y}" width="${width}" height="${height}"/>
-                                <accessibility key="accessibilityConfiguration">
-                                    <accessibilityTraits key="traits" image="YES" notEnabled="YES"/>
-                                </accessibility>
-                            </imageView>
-                        </subviews>
-                        <color key="backgroundColor" red="${r}" green="${g}" blue="${b}" alpha="1" colorSpace="calibratedRGB"/>
-                        <accessibility key="accessibilityConfiguration">
-                            <accessibilityTraits key="traits" notEnabled="YES"/>
-                        </accessibility>
-                        <constraints>
-                            <constraint firstItem="3lX-Ut-9ad" firstAttribute="centerX" secondItem="eg9-kz-Dhh" secondAttribute="centerX" id="Fh9-Fy-1nT"/>
-                            <constraint firstItem="3lX-Ut-9ad" firstAttribute="centerY" secondItem="guO-oA-Nhw" secondAttribute="centerY" id="nvB-Ic-PnI"/>
-                        </constraints>
-                        <viewLayoutGuide key="safeArea" id="eg9-kz-Dhh"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Lvb-Jr-bCV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="0.0" y="0.0"/>
-        </scene>
-    </scenes>
-    <resources>
-        <image name="${xcassetName}" width="${width}" height="${height}"/>
-    </resources>
-</document>
-`;
-};
-
-const drawableXml = `<?xml version="1.0" encoding="utf-8"?>
-
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android" android:opacity="opaque">
-    <item android:drawable="@color/bootsplash_background" />
-
-    <item>
-        <bitmap android:src="@mipmap/${logoFileName}" android:gravity="center" />
-    </item>
-</layer-list>
-`;
-
 const log = (text, dim = false) => {
   console.log(dim ? chalk.dim(text) : text);
 };
 
-const ensureDir = (dir) => {
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir);
-  }
-};
-
 const isValidHexadecimal = (value) => /^#?([0-9A-F]{3}){1,2}$/i.test(value);
-
-const toFullHexadecimal = (hex) => {
-  const prefixed = hex[0] === "#" ? hex : `#${hex}`;
-  const up = prefixed.toUpperCase();
-
-  return up.length === 4
-    ? "#" + up[1] + up[1] + up[2] + up[2] + up[3] + up[3]
-    : up;
-};
-
-const hexadecimalToAppleColor = (hex) => ({
-  r: (parseInt(hex[1] + hex[2], 16) / 255).toPrecision(15),
-  g: (parseInt(hex[3] + hex[4], 16) / 255).toPrecision(15),
-  b: (parseInt(hex[5] + hex[6], 16) / 255).toPrecision(15),
-});
 
 const getProjectName = (projectPath) => {
   try {
@@ -239,163 +126,6 @@ const questions = [
     initial: true,
   },
 ];
-
-async function generate({
-  projectPath,
-  assetsPath,
-  iconPath,
-  backgroundColor,
-  iconWidth: w1,
-  confirmation,
-}) {
-  if (!projectPath || !assetsPath || !iconPath || !w1 || !confirmation) {
-    process.exit(1);
-  }
-
-  const image = await jimp.read(iconPath);
-  const imageMap = [];
-
-  const fullHexadecimal = toFullHexadecimal(backgroundColor);
-  const appleColors = hexadecimalToAppleColor(fullHexadecimal);
-
-  const h = (size) =>
-    Math.ceil(size * (image.bitmap.height / image.bitmap.width));
-
-  const w15 = w1 * 1.5;
-  const w2 = w1 * 2;
-  const w3 = w1 * 3;
-  const w4 = w1 * 4;
-
-  const androidResPath = path.join(
-    projectPath,
-    "android",
-    "app",
-    "src",
-    "main",
-    "res",
-  );
-
-  if (fs.existsSync(androidResPath)) {
-    const fileName = `${logoFileName}.png`;
-
-    imageMap.push(
-      [path.join(androidResPath, "mipmap-mdpi", fileName), [w1, h(w1)]],
-      [path.join(androidResPath, "mipmap-hdpi", fileName), [w15, h(w15)]],
-      [path.join(androidResPath, "mipmap-xhdpi", fileName), [w2, h(w2)]],
-      [path.join(androidResPath, "mipmap-xxhdpi", fileName), [w3, h(w3)]],
-      [path.join(androidResPath, "mipmap-xxxhdpi", fileName), [w4, h(w4)]],
-    );
-  } else {
-    log(`No ${androidResPath} directory found. Skipping android generation…`);
-  }
-
-  const iosProjectPath = path.join(projectPath, "ios", projectName);
-  const iosImagesPath = path.join(iosProjectPath, "Images.xcassets");
-
-  if (fs.existsSync(iosImagesPath)) {
-    const iosImageSetPath = path.join(iosImagesPath, `${xcassetName}.imageset`);
-    ensureDir(iosImageSetPath);
-
-    fs.writeFileSync(
-      path.join(iosImageSetPath, "Contents.json"),
-      ContentsJson,
-      "utf-8",
-    );
-
-    imageMap.push(
-      [path.join(iosImageSetPath, `${logoFileName}.png`), [w1, h(w1)]],
-      [path.join(iosImageSetPath, `${logoFileName}@2x.png`), [w2, h(w2)]],
-      [path.join(iosImageSetPath, `${logoFileName}@3x.png`), [w3, h(w3)]],
-    );
-  } else {
-    log(`No ${iosImagesPath} directory found. Skipping iOS generation…`);
-  }
-
-  imageMap.push(
-    [path.join(assetsPath, logoFileName + ".png"), [w1, h(w1)]],
-    [path.join(assetsPath, logoFileName + "@1,5x.png"), [w15, h(w15)]],
-    [path.join(assetsPath, logoFileName + "@2x.png"), [w2, h(w2)]],
-    [path.join(assetsPath, logoFileName + "@3x.png"), [w3, h(w3)]],
-    [path.join(assetsPath, logoFileName + "@4x.png"), [w4, h(w4)]],
-  );
-
-  log("👍  Looking good! Generating files…");
-
-  await Promise.all(
-    imageMap.map(([path, [width, height]]) =>
-      image
-        .clone()
-        .cover(width, height)
-        .writeAsync(path)
-        .then(() => {
-          log(`✨  ${path} (${width}x${height})`, true);
-        }),
-    ),
-  );
-
-  if (fs.existsSync(iosProjectPath)) {
-    const storyboard = path.join(iosProjectPath, `BootSplash.storyboard`);
-
-    fs.writeFileSync(
-      storyboard,
-      getStoryboard({ height: h(w1), width: w1, ...appleColors }),
-      "utf-8",
-    );
-
-    log(`✨  ${storyboard}`, true);
-  }
-
-  if (fs.existsSync(androidResPath)) {
-    const drawableDir = path.join(androidResPath, "drawable");
-    ensureDir(drawableDir);
-    const drawable = path.join(drawableDir, "bootsplash.xml");
-    fs.writeFileSync(drawable, drawableXml, "utf-8");
-
-    log(`✨  ${drawable}`, true);
-
-    const valuesDir = path.join(androidResPath, "values");
-    ensureDir(valuesDir);
-    const colors = path.join(valuesDir, "colors.xml");
-
-    if (fs.existsSync(colors)) {
-      const content = fs.readFileSync(colors, "utf-8");
-
-      if (content.match(androidColorRegex)) {
-        fs.writeFileSync(
-          colors,
-          content.replace(
-            androidColorRegex,
-            `<color name="bootsplash_background">${fullHexadecimal}</color>`,
-          ),
-          "utf-8",
-        );
-      } else {
-        fs.writeFileSync(
-          colors,
-          content.replace(
-            /<\/resources>/g,
-            `    <color name="bootsplash_background">${fullHexadecimal}</color>\n</resources>`,
-          ),
-          "utf-8",
-        );
-      }
-
-      log(`✏️   Editing ${colors}`, true);
-    } else {
-      fs.writeFileSync(
-        colors,
-        `<resources>\n    <color name="bootsplash_background">${fullHexadecimal}</color>\n</resources>\n`,
-        "utf-8",
-      );
-
-      log(`✨  ${colors}`, true);
-    }
-  }
-
-  log(
-    `✅  Done! Thanks for using ${chalk.underline("react-native-bootsplash")}.`,
-  );
-}
 
 prompts(questions)
   .then(generate)

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,7 +617,7 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
   integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
@@ -742,33 +742,33 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jest/types@^25.3.0":
-  version "25.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.3.0.tgz#88f94b277a1d028fd7117bc1f74451e0fc2131e7"
-  integrity sha512-UkaDNewdqXAmCDbN2GlUM6amDKS78eCqiw/UmF5nE0mmLTd6moJkiZJML/X52Ke3LH7Swhw883IRXq8o9nWjVw==
+"@jest/types@^25.4.0":
+  version "25.4.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.4.0.tgz#5afeb8f7e1cba153a28e5ac3c9fe3eede7206d59"
+  integrity sha512-XBeaWNzw2PPnGW5aXvZt3+VO60M+34RY3XDsCK5tW7kyj3RK0XClRutCfjqcBuaR2aBQTbluEDME9b5MB9UAPw==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@jimp/bmp@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/bmp/-/bmp-0.10.1.tgz#e42889f98b1a1ed1fedd1d5cbeaec6ce6a618a56"
-  integrity sha512-gy4ftMCgBZOx1e/Q+MaJlmU4qgqVqwGdf7G6byYTLEMUzzGK2Ipxf3nlXfkMOZqw7Bhc17zDnBIKluo7k0kX5Q==
+"@jimp/bmp@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/bmp/-/bmp-0.10.3.tgz#79a23678e8389865c62e77b0dccc3e069dfc27f0"
+  integrity sha512-keMOc5woiDmONXsB/6aXLR4Z5Q+v8lFq3EY2rcj2FmstbDMhRuGbmcBxlEgOqfRjwvtf/wOtJ3Of37oAWtVfLg==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     bmp-js "^0.1.0"
     core-js "^3.4.1"
 
-"@jimp/core@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/core/-/core-0.10.1.tgz#9c7cee4a1a151786a53d6c5defb141f640396cf9"
-  integrity sha512-ChyLkGb1+x2mRpsdcnQuRNb523qVqUc7+zCbuO/VAMaqvbMKuRalVz3aHXcVwNi8vOAOgce4LOBT7kjdKTtR/w==
+"@jimp/core@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/core/-/core-0.10.3.tgz#4095f3bef43837c85d8f8373b912bc431cfe6d1f"
+  integrity sha512-Gd5IpL3U2bFIO57Fh/OA3HCpWm4uW/pU01E75rI03BXfTdz3T+J7TwvyG1XaqsQ7/DSlS99GXtLQPlfFIe28UA==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     any-base "^1.1.0"
     buffer "^5.2.0"
     core-js "^3.4.1"
@@ -781,310 +781,318 @@
     tinycolor2 "^1.4.1"
 
 "@jimp/custom@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/custom/-/custom-0.10.1.tgz#1147f895272351adc3fd8192b73a2d4ccf563535"
-  integrity sha512-hiiOL5sGcV1p8hCFTabALUOmXs4VP9VwhfBZtsFueKGbwWz6dmaZvkMBsk3Mz1ukBP3xb09goWG+zAIdTm88fw==
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/custom/-/custom-0.10.3.tgz#eb6201b2e8fdd83afc3d8b514538e5faa1d30980"
+  integrity sha512-nZmSI+jwTi5IRyNLbKSXQovoeqsw+D0Jn0SxW08wYQvdkiWA8bTlDQFgQ7HVwCAKBm8oKkDB/ZEo9qvHJ+1gAQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/core" "^0.10.1"
+    "@jimp/core" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/gif@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/gif/-/gif-0.10.1.tgz#fc238448cd8e367f9d73ed98347b083f0e71a184"
-  integrity sha512-xJwZ6JI6+GmrgTw///YdV8GY1z2dp4AAxEdm/KPozTvS2rygC8OZJcTmlswFws0UCH43rKzJlQUXa4Jb3ybB6w==
+"@jimp/gif@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/gif/-/gif-0.10.3.tgz#7661280fd2b9cb70175b20e80f4e2b3e3ecf614e"
+  integrity sha512-vjlRodSfz1CrUvvrnUuD/DsLK1GHB/yDZXHthVdZu23zYJIW7/WrIiD1IgQ5wOMV7NocfrvPn2iqUfBP81/WWA==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
     omggif "^1.0.9"
 
-"@jimp/jpeg@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/jpeg/-/jpeg-0.10.1.tgz#93708ce2981772dd510670b78eacf703bb66a9f4"
-  integrity sha512-PXxrBWZNNGpm7PRpdi2jt9fpTpQwe2Gf4juwuHXP/dBFHLk3wiI/npKkVITplwzzoQ6D4N0cb279c9bOpuQeJQ==
+"@jimp/jpeg@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/jpeg/-/jpeg-0.10.3.tgz#56f66874f204826291747ae12ff9eb337ab5cb8d"
+  integrity sha512-AAANwgUZOt6f6P7LZxY9lyJ9xclqutYJlsxt3JbriXUGJgrrFAIkcKcqv1nObgmQASSAQKYaMV9KdHjMlWFKlQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
     jpeg-js "^0.3.4"
 
-"@jimp/plugin-blit@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-blit/-/plugin-blit-0.10.1.tgz#fcd2d031294faf6f932e96f151df4c82e2b90f89"
-  integrity sha512-53647EfRvPQJKQCMBc5AJGSZHyl6eueaOQq7PrfxEEq9Q3IjVcikAWYrZ4bHSZY7J12IIuz/5bSLJJZfegNQtA==
+"@jimp/plugin-blit@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-blit/-/plugin-blit-0.10.3.tgz#095bafbb2d82c300159334a49a094f0b7d362ae6"
+  integrity sha512-5zlKlCfx4JWw9qUVC7GI4DzXyxDWyFvgZLaoGFoT00mlXlN75SarlDwc9iZ/2e2kp4bJWxz3cGgG4G/WXrbg3Q==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-blur@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-blur/-/plugin-blur-0.10.1.tgz#2f9f6e494183a4044cffb1883bbdff42aee914ea"
-  integrity sha512-0PzdzPGuv8RlhiMbLcM0tIekkHhuaPTY+frEWmO8BuCeqW9Tg9W4RxdwZtMqIVRG+kZBgyltYee31Q4JWlu9Hg==
+"@jimp/plugin-blur@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-blur/-/plugin-blur-0.10.3.tgz#1bb91f730fda02b3c99d913e0191111327654766"
+  integrity sha512-cTOK3rjh1Yjh23jSfA6EHCHjsPJDEGLC8K2y9gM7dnTUK1y9NNmkFS23uHpyjgsWFIoH9oRh2SpEs3INjCpZhQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-circle@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-circle/-/plugin-circle-0.10.1.tgz#73184655fa0de586efbbda9675b3233fcd621a0a"
-  integrity sha512-sqiiEddN81N9xHZbPVjaJlbpQabaCeNGLW/x+0BfuNxnMPq7OkOx8IRpqIDYiGuuPhiR5hWxmmpws8ZAhjwsVw==
+"@jimp/plugin-circle@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-circle/-/plugin-circle-0.10.3.tgz#c5a6ec275cf1e86b1356824637910a299c9fd662"
+  integrity sha512-51GAPIVelqAcfuUpaM5JWJ0iWl4vEjNXB7p4P7SX5udugK5bxXUjO6KA2qgWmdpHuCKtoNgkzWU9fNSuYp7tCA==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-color@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-color/-/plugin-color-0.10.1.tgz#1b80654cbf4cd0bf6663b5ca94aa7317b8827e3d"
-  integrity sha512-SmW2+hFtNmQ33WYVsgKvreS8peCc5qItAvqGR58lKNoIMEZSNpyGwIu9g83HtDIImGsXpz3DWGMR1h8sLYCFcQ==
+"@jimp/plugin-color@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-color/-/plugin-color-0.10.3.tgz#810c0f7cb4ceb21da1aecfbdb6ae09f00c1c0bfa"
+  integrity sha512-RgeHUElmlTH7vpI4WyQrz6u59spiKfVQbsG/XUzfWGamFSixa24ZDwX/yV/Ts+eNaz7pZeIuv533qmKPvw2ujg==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
     tinycolor2 "^1.4.1"
 
-"@jimp/plugin-contain@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-contain/-/plugin-contain-0.10.1.tgz#ca998fff6622e64f9ff9a5e6e5685fa3730fc8d1"
-  integrity sha512-1PkmUPd5iAicAI7QjO9r1Mp/Ia7ElJPwXTCNLsQkDxYS/L4u7vQ0xCkQkokAeR49Ul3GTWLqj9paWr7VSBG9Fg==
+"@jimp/plugin-contain@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-contain/-/plugin-contain-0.10.3.tgz#cf62126a60260359061be456b2193818c5eb1df5"
+  integrity sha512-bYJKW9dqzcB0Ihc6u7jSyKa3juStzbLs2LFr6fu8TzA2WkMS/R8h+ddkiO36+F9ILTWHP0CIA3HFe5OdOGcigw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-cover@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-cover/-/plugin-cover-0.10.1.tgz#12de082cec1de678623880ac3f82bcf89efea7cd"
-  integrity sha512-fCiz+ugrRwffNixUHFxtRKhTYm8sFAoYbNNzV0WdiG8dS0qhoYjbOJPtLcIw9CyJbMZ5eXjGOTxhTAGzBng9DA==
+"@jimp/plugin-cover@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-cover/-/plugin-cover-0.10.3.tgz#7cdf56ce878c24adc35c583735015118c6de38b4"
+  integrity sha512-pOxu0cM0BRPzdV468n4dMocJXoMbTnARDY/EpC3ZW15SpMuc/dr1KhWQHgoQX5kVW1Wt8zgqREAJJCQ5KuPKDA==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-crop@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-crop/-/plugin-crop-0.10.1.tgz#40f20d8adcf83a7dd49ce40468afe82df72e16c4"
-  integrity sha512-KjW+RuuNcsIvvNF1ejbBjcDNus/fLz69LGAU2gwhFzw7A0iOUEJJgTWzkGBLZ/YvUaWMDtPnznF3X3oYHeOj6A==
+"@jimp/plugin-crop@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-crop/-/plugin-crop-0.10.3.tgz#03785181f62ddae9558ae73206f8d6217d7fa703"
+  integrity sha512-nB7HgOjjl9PgdHr076xZ3Sr6qHYzeBYBs9qvs3tfEEUeYMNnvzgCCGtUl6eMakazZFCMk3mhKmcB9zQuHFOvkg==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-displace@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-displace/-/plugin-displace-0.10.1.tgz#fcf683adc4b4bfdd27c77045fc2abeff6521669a"
-  integrity sha512-NUJcjMRb6iR9rwJSC7t8LMJgRs5Z0mzflYBymvttkjlcIoB4RPIOu3gWn5iT5IepB50YTy9zJuCaofMYn4DnaA==
+"@jimp/plugin-displace@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-displace/-/plugin-displace-0.10.3.tgz#cb5b225e6cf3cf44062b08cd2cf2115b3150d8c3"
+  integrity sha512-8t3fVKCH5IVqI4lewe4lFFjpxxr69SQCz5/tlpDLQZsrNScNJivHdQ09zljTrVTCSgeCqQJIKgH2Q7Sk/pAZ0w==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-dither@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-dither/-/plugin-dither-0.10.1.tgz#c75650274b82c0b140f7b9db26167169729742a2"
-  integrity sha512-V/PCL44R16w5EDCgMvFXBaWFQ0f3LLDD3CQxJFOw6awswkP60m13nUUtWHm7QB54Gghhgk8JEOD/mZo6JsnaBg==
+"@jimp/plugin-dither@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-dither/-/plugin-dither-0.10.3.tgz#c5c1cbbf157a771ba72b947dd9921a7bff3cf41a"
+  integrity sha512-JCX/oNSnEg1kGQ8ffZ66bEgQOLCY3Rn+lrd6v1jjLy/mn9YVZTMsxLtGCXpiCDC2wG/KTmi4862ysmP9do9dAQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-fisheye@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-fisheye/-/plugin-fisheye-0.10.1.tgz#f482d913d00ef4149e7d4fcce517dd9acc564846"
-  integrity sha512-GgIAY6ryL+2RwRb6j+APo972f8VjftolnvjVM1ilxO4pdfJf7gdg3Bp4igka9fgW94BBgdJlCPUeWIVap3AYaA==
+"@jimp/plugin-fisheye@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-fisheye/-/plugin-fisheye-0.10.3.tgz#dee46d704df5c681556dc9ea9e87e8c77ac4fdda"
+  integrity sha512-RRZb1wqe+xdocGcFtj2xHU7sF7xmEZmIa6BmrfSchjyA2b32TGPWKnP3qyj7p6LWEsXn+19hRYbjfyzyebPElQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-flip@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-flip/-/plugin-flip-0.10.1.tgz#e311365b859168b0bef338566868bab9d2ae397d"
-  integrity sha512-CkSwULwmVYOo6ZY/QnR0/mrfMaf/3g+sDo7osAHaf0GvuoIw76NSh6LwaANAsLZ9erknZ67XuqCjZWoMwNrbaw==
+"@jimp/plugin-flip@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-flip/-/plugin-flip-0.10.3.tgz#12f894f85b283ad4f43b492e0755f8ec9459bc60"
+  integrity sha512-0epbi8XEzp0wmSjoW9IB0iMu0yNF17aZOxLdURCN3Zr+8nWPs5VNIMqSVa1Y62GSyiMDpVpKF/ITiXre+EqrPg==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-gaussian@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-gaussian/-/plugin-gaussian-0.10.1.tgz#9c409d7f455397d26acd953c5f03368018d0c38f"
-  integrity sha512-RnmIWUr9RB1RrgqXG2H7C3dyncak/D2CPoP2DehAgxxHprDdxm9HoFjhGQ9eh+Ygr0nXE7t2+fDE12U3VW3ApA==
+"@jimp/plugin-gaussian@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-gaussian/-/plugin-gaussian-0.10.3.tgz#279222fc5d3aec24fab6162df2a1190309c71874"
+  integrity sha512-25eHlFbHUDnMMGpgRBBeQ2AMI4wsqCg46sue0KklI+c2BaZ+dGXmJA5uT8RTOrt64/K9Wz5E+2n7eBnny4dfpQ==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-invert@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-invert/-/plugin-invert-0.10.1.tgz#cf5e711c1cd864bb4fc46bd00a8b2a40d5058a61"
-  integrity sha512-PpTUbnjsAkw0nZnbZWrKdsEW46MARhzzabBXy/XCjvutG3jzoO8EL19VeEtcrxBml9duJbaOzdzYmbFkQsNINQ==
+"@jimp/plugin-invert@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-invert/-/plugin-invert-0.10.3.tgz#6b7beacbe507fa03eec87b1d6343feba80e342eb"
+  integrity sha512-effYSApWY/FbtlzqsKXlTLkgloKUiHBKjkQnqh5RL4oQxh/33j6aX+HFdDyQKtsXb8CMd4xd7wyiD2YYabTa0g==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-mask@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-mask/-/plugin-mask-0.10.1.tgz#4ed7ade8b37eca9493977703c26ad64e748460ad"
-  integrity sha512-Fm75MSucSGI19n9beXGVPSR98flXpzJLyOfSj0+zefXafrO+kmYO9eWtzNd3TE6jzyGe5y7mPJPHB0PWXKgw4g==
+"@jimp/plugin-mask@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-mask/-/plugin-mask-0.10.3.tgz#72d994c3bb56c050a4edd6515f74b5b6d92dee69"
+  integrity sha512-twrg8q8TIhM9Z6Jcu9/5f+OCAPaECb0eKrrbbIajJqJ3bCUlj5zbfgIhiQIzjPJ6KjpnFPSqHQfHkU1Vvk/nVw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-normalize@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-normalize/-/plugin-normalize-0.10.1.tgz#fadd955754ea077afb0fb59352c54088a9ca0981"
-  integrity sha512-mxjRCmUB/yD973pgjAKb3HCYMyh1GvGtdo71+pJn+ChefvTJ0LDB1FknwTVjDtJuy4mBh0TkBqBp4PNAtdBL6w==
+"@jimp/plugin-normalize@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-normalize/-/plugin-normalize-0.10.3.tgz#f3cbb8a0fcc8e696619d5d46403b0620ee5240d6"
+  integrity sha512-xkb5eZI/mMlbwKkDN79+1/t/+DBo8bBXZUMsT4gkFgMRKNRZ6NQPxlv1d3QpRzlocsl6UMxrHnhgnXdLAcgrXw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-print@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-print/-/plugin-print-0.10.1.tgz#d39a01b5bf8a3087e102637920672ff45f1e5047"
-  integrity sha512-eSPTbdES/ISR9nMHV8e449UMs0Dx0eY9OixU7gIYTDnTmnhyYXq9bqIY/IXqVU3fOj330MIpIpi6pavmtJXdLA==
+"@jimp/plugin-print@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-print/-/plugin-print-0.10.3.tgz#565d57a3a87dd59b4ede9cba7a6e34f8d01ed1b1"
+  integrity sha512-wjRiI6yjXsAgMe6kVjizP+RgleUCLkH256dskjoNvJzmzbEfO7xQw9g6M02VET+emnbY0CO83IkrGm2q43VRyg==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
     load-bmfont "^1.4.0"
 
-"@jimp/plugin-resize@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-resize/-/plugin-resize-0.10.1.tgz#0a294b8dae1efd96ac53bdcd40f7ab58cc2e4f5e"
-  integrity sha512-aG42+tRmhAYKvybZteSD7s48dAcYSkipyM+e2aizRa0D0FHNIQlIHribiKfRTiX+ewx/fhHVu0vpFKOg0N2hDw==
+"@jimp/plugin-resize@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-resize/-/plugin-resize-0.10.3.tgz#616fab55a1996a12e9583e7c1fb76815388fc14b"
+  integrity sha512-rf8YmEB1d7Sg+g4LpqF0Mp+dfXfb6JFJkwlAIWPUOR7lGsPWALavEwTW91c0etEdnp0+JB9AFpy6zqq7Lwkq6w==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-rotate@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-rotate/-/plugin-rotate-0.10.1.tgz#4e0315cc582afdde90a4f8b56434046c49da015f"
-  integrity sha512-R+Qpb3cwKl6L5m9RUkJatY5D5JuPg/uUfFbdFPaBhc5infC46Rsyt0j923eUyXkisechRDmzoTbG3fcc1MjzSA==
+"@jimp/plugin-rotate@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-rotate/-/plugin-rotate-0.10.3.tgz#cfcbdad664e13c84ce9b008ddbc157e03d7baa31"
+  integrity sha512-YXLlRjm18fkW9MOHUaVAxWjvgZM851ofOipytz5FyKp4KZWDLk+dZK1JNmVmK7MyVmAzZ5jsgSLhIgj+GgN0Eg==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-scale@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-scale/-/plugin-scale-0.10.1.tgz#e5cf6150867738c5c4fa9e04f125a9d714b21b67"
-  integrity sha512-MKmW3Rr0sSApglUYFqJ8LgGy9Nm9w2oRgSB2twxA5bp1waM9fdOILcRyEnltwHIIDSoyR0me8XmpuwpyqaqSdA==
+"@jimp/plugin-scale@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-scale/-/plugin-scale-0.10.3.tgz#b593081ff35b0e9e11d5e0a3188c590eaa838434"
+  integrity sha512-5DXD7x7WVcX1gUgnlFXQa8F+Q3ThRYwJm+aesgrYvDOY+xzRoRSdQvhmdd4JEEue3lyX44DvBSgCIHPtGcEPaw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-shadow@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-shadow/-/plugin-shadow-0.10.1.tgz#d564a1ac7552c2423fb4b41c4af78a84b8177032"
-  integrity sha512-H4JSVimD19vbFiX8SL3Ci5Htsbb3xG8zQrkjf+ui/2MXbeP0FyWlIv3g1Ahil4oE+5Wi4zbq20Dyba2GS4aINw==
+"@jimp/plugin-shadow@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-shadow/-/plugin-shadow-0.10.3.tgz#a9d54c8081a55152e5cc830cf5c898ab882b519a"
+  integrity sha512-/nkFXpt2zVcdP4ETdkAUL0fSzyrC5ZFxdcphbYBodqD7fXNqChS/Un1eD4xCXWEpW8cnG9dixZgQgStjywH0Mg==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
-"@jimp/plugin-threshold@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugin-threshold/-/plugin-threshold-0.10.1.tgz#4097c91aab749b140f7edc4c7066803a69bf9fb3"
-  integrity sha512-o2nBEz2tLvfYNMdac9qho5SrjFoBfbJow8PWXMWz14N6zLKIw4DQT+inSbEKxbxlqKseds3zUsOIM+0hLbSDeQ==
+"@jimp/plugin-threshold@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-threshold/-/plugin-threshold-0.10.3.tgz#8dd289c81de4bfbdb496f9c24496f9ee3b751ab5"
+  integrity sha512-Dzh0Yq2wXP2SOnxcbbiyA4LJ2luwrdf1MghNIt9H+NX7B+IWw/N8qA2GuSm9n4BPGSLluuhdAWJqHcTiREriVA==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
 
 "@jimp/plugins@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/plugins/-/plugins-0.10.1.tgz#e9a126bbed7058e6351d08454249a7934d4bd69c"
-  integrity sha512-gpdoh7XITd33ZClObVKYV8ASpZnrwebNuY4C5njeJfLxfyRQ2wSK9TDAb/5OYcyrbMDIqBaKLg9AXHPBphwXtg==
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/plugins/-/plugins-0.10.3.tgz#e15d7ba3f9e2a6b479efad5c344c8b61e01b7cb2"
+  integrity sha512-jTT3/7hOScf0EIKiAXmxwayHhryhc1wWuIe3FrchjDjr9wgIGNN2a7XwCgPl3fML17DXK1x8EzDneCdh261bkw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/plugin-blit" "^0.10.1"
-    "@jimp/plugin-blur" "^0.10.1"
-    "@jimp/plugin-circle" "^0.10.1"
-    "@jimp/plugin-color" "^0.10.1"
-    "@jimp/plugin-contain" "^0.10.1"
-    "@jimp/plugin-cover" "^0.10.1"
-    "@jimp/plugin-crop" "^0.10.1"
-    "@jimp/plugin-displace" "^0.10.1"
-    "@jimp/plugin-dither" "^0.10.1"
-    "@jimp/plugin-fisheye" "^0.10.1"
-    "@jimp/plugin-flip" "^0.10.1"
-    "@jimp/plugin-gaussian" "^0.10.1"
-    "@jimp/plugin-invert" "^0.10.1"
-    "@jimp/plugin-mask" "^0.10.1"
-    "@jimp/plugin-normalize" "^0.10.1"
-    "@jimp/plugin-print" "^0.10.1"
-    "@jimp/plugin-resize" "^0.10.1"
-    "@jimp/plugin-rotate" "^0.10.1"
-    "@jimp/plugin-scale" "^0.10.1"
-    "@jimp/plugin-shadow" "^0.10.1"
-    "@jimp/plugin-threshold" "^0.10.1"
+    "@jimp/plugin-blit" "^0.10.3"
+    "@jimp/plugin-blur" "^0.10.3"
+    "@jimp/plugin-circle" "^0.10.3"
+    "@jimp/plugin-color" "^0.10.3"
+    "@jimp/plugin-contain" "^0.10.3"
+    "@jimp/plugin-cover" "^0.10.3"
+    "@jimp/plugin-crop" "^0.10.3"
+    "@jimp/plugin-displace" "^0.10.3"
+    "@jimp/plugin-dither" "^0.10.3"
+    "@jimp/plugin-fisheye" "^0.10.3"
+    "@jimp/plugin-flip" "^0.10.3"
+    "@jimp/plugin-gaussian" "^0.10.3"
+    "@jimp/plugin-invert" "^0.10.3"
+    "@jimp/plugin-mask" "^0.10.3"
+    "@jimp/plugin-normalize" "^0.10.3"
+    "@jimp/plugin-print" "^0.10.3"
+    "@jimp/plugin-resize" "^0.10.3"
+    "@jimp/plugin-rotate" "^0.10.3"
+    "@jimp/plugin-scale" "^0.10.3"
+    "@jimp/plugin-shadow" "^0.10.3"
+    "@jimp/plugin-threshold" "^0.10.3"
     core-js "^3.4.1"
     timm "^1.6.1"
 
-"@jimp/png@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/png/-/png-0.10.1.tgz#aff93621b278bca73e46bf951d2e44b1381c5139"
-  integrity sha512-/2CUaOjbq5GVaXKRGzM4nhhFpnVdWNazsuVZ3Et8sgMxJxep7v6k2hmvL8rr0/A4UPPWzEbFsagz/YBbN9fANw==
+"@jimp/png@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/png/-/png-0.10.3.tgz#5282cad239d02743137d88239e4cb1804ed877dd"
+  integrity sha512-YKqk/dkl+nGZxSYIDQrqhmaP8tC3IK8H7dFPnnzFVvbhDnyYunqBZZO3SaZUKTichClRw8k/CjBhbc+hifSGWg==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/utils" "^0.10.1"
+    "@jimp/utils" "^0.10.3"
     core-js "^3.4.1"
     pngjs "^3.3.3"
 
-"@jimp/tiff@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/tiff/-/tiff-0.10.1.tgz#602e5d7c3434094e5e29642659af2f5da0061e12"
-  integrity sha512-lvCzid4RwCZr/Zz3W4xTD/UKe4xjVdPk2dGGozrW0Puo2TCz5L+ghXYEWxzoj/rm/wOFmQbaYdopv0UQ72HqWw==
+"@jimp/tiff@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/tiff/-/tiff-0.10.3.tgz#6d143bbc42b40c9f618686a596311b35f7ff8502"
+  integrity sha512-7EsJzZ5Y/EtinkBGuwX3Bi4S+zgbKouxjt9c82VJTRJOQgLWsE/RHqcyRCOQBhHAZ9QexYmDz34medfLKdoX0g==
   dependencies:
     "@babel/runtime" "^7.7.2"
     core-js "^3.4.1"
     utif "^2.0.1"
 
 "@jimp/types@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/types/-/types-0.10.1.tgz#7cbeff8b189b2d7c49b8f8bdaee4d6c814d8e4ff"
-  integrity sha512-PaPhpeHE41Yn6myvnHmrb1FNvn+XmF+EpizhP8JR3DmyveUPblrssM8qA5iMe+Q+wG3vJ02LHNgbfFCUYJr3zA==
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/types/-/types-0.10.3.tgz#9122e0a3c70129c7f26c05bbeae5030ed3a6fd5d"
+  integrity sha512-XGmBakiHZqseSWr/puGN+CHzx0IKBSpsKlmEmsNV96HKDiP6eu8NSnwdGCEq2mmIHe0JNcg1hqg59hpwtQ7Tiw==
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@jimp/bmp" "^0.10.1"
-    "@jimp/gif" "^0.10.1"
-    "@jimp/jpeg" "^0.10.1"
-    "@jimp/png" "^0.10.1"
-    "@jimp/tiff" "^0.10.1"
+    "@jimp/bmp" "^0.10.3"
+    "@jimp/gif" "^0.10.3"
+    "@jimp/jpeg" "^0.10.3"
+    "@jimp/png" "^0.10.3"
+    "@jimp/tiff" "^0.10.3"
     core-js "^3.4.1"
     timm "^1.6.1"
 
-"@jimp/utils@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@jimp/utils/-/utils-0.10.1.tgz#35187bd28268dbb4cfc2b07c71e59f6be0303bf8"
-  integrity sha512-Q0ZT2FGPQo3lXkUheAsg0dVWo0Ko+vYCVJLEUxQMxmPiDLUquE22iya+tMONPOaRj1GG3cznaSqaEHDNgoyYbw==
+"@jimp/utils@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@jimp/utils/-/utils-0.10.3.tgz#69209dd6c2d6fd956a0beb67a47c26cb6f52f3fe"
+  integrity sha512-VcSlQhkil4ReYmg1KkN+WqHyYfZ2XfZxDsKAHSfST1GEz/RQHxKZbX+KhFKtKflnL0F4e6DlNQj3vznMNXCR2w==
   dependencies:
     "@babel/runtime" "^7.7.2"
     core-js "^3.4.1"
     regenerator-runtime "^0.13.3"
 
-"@react-native-community/cli-debugger-ui@^4.6.3":
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.6.3.tgz#5e93bf170a092a011f1bb0e19886f94265a4ce97"
-  integrity sha512-5hnzGBP1eXmc1gOuKm9x5uyw9z5QE3C2pSz57eaV6dHjl9LKfeBXd9L+RqeG/uWi7buE4YyJwirvpufLREoyJg==
+"@raydeck/xcode@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@raydeck/xcode/-/xcode-2.2.1.tgz#fd94c3b1908ad15ad9a82fde298b87bf08238289"
+  integrity sha512-464tAzmcJLL0A4W5vKP3t3s6mRLnwGWE/cHo+I+0mHJiSzojSwHIZK7i3shFJioyQFHPxYndzRzTu2VOjdpBcQ==
+  dependencies:
+    simple-plist "^0.2.1"
+    uuid "3.0.1"
+
+"@react-native-community/cli-debugger-ui@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.7.0.tgz#4a8689f56b99378b24bbbf0ff6a89869d667f013"
+  integrity sha512-Z/xJ08Wz3J2fKDPrwxtQ44XSHnWsF6dnT0H2AANw63bWjnrR0E3sh8Nk8/oO+j9R7LH8S0+NHJdlniXYtL/bNg==
   dependencies:
     serve-static "^1.13.1"
 
 "@react-native-community/cli-platform-android@^4.5.1":
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-4.6.3.tgz#a7377b97cb85b5714d063281eed8e4185444569d"
-  integrity sha512-o88nUW2mjwvYSTwW/VTPdMmTi2vHS4T4gYGObb3qgkv/6H0JG1NC0SRo1FCHRpRGo1nQ7d+aB8sfpJeEkQ3Mbw==
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-4.7.0.tgz#aace6b8004b8d3aae40d6affaad1c472e0310a25"
+  integrity sha512-Lb6D0ipmFwYLJeQy5/NI4uJpeSHw85rd84C40wwpoUfsCgZhA93WUJdFkuQEIDkfTqs5Yqgl+/szhIZdnIXPxw==
   dependencies:
-    "@react-native-community/cli-tools" "^4.6.3"
+    "@react-native-community/cli-tools" "^4.7.0"
     chalk "^3.0.0"
     execa "^1.0.0"
     fs-extra "^8.1.0"
@@ -1096,11 +1104,11 @@
     xmldoc "^1.1.2"
 
 "@react-native-community/cli-platform-ios@^4.5.0":
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-4.6.3.tgz#bcd317e4b6d391a872f04de80fd6e56dbf8a5ba7"
-  integrity sha512-blYP5DBVj3ZefmKvMsMvmOWrw3Fl6bQIvAAMt+J1nqhZKOONpunfKgKi9DmE/Pzxxdmsx/HhtV104OnBdtUPbw==
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-4.7.0.tgz#471dcdbd2645c5650f16c0eddcca50e47ca78398"
+  integrity sha512-XqnxP6H6+PG/wn4+Pwas5jaTSr5n7x6v8trkPY8iO37b8sq7tJLNYznaBMROF43i0NqO48JdhquYOqnDN8FdBA==
   dependencies:
-    "@react-native-community/cli-tools" "^4.6.3"
+    "@react-native-community/cli-tools" "^4.7.0"
     chalk "^3.0.0"
     glob "^7.1.3"
     js-yaml "^3.13.1"
@@ -1108,30 +1116,30 @@
     plist "^3.0.1"
     xcode "^2.0.0"
 
-"@react-native-community/cli-tools@^4.6.3":
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-4.6.3.tgz#dab9ce5fc45ae8847caa9f6cc85b67b284777b1f"
-  integrity sha512-ne/A1JUA86WgS3LpdqCwdpCbzfLJusfTllv+TDafNxEdziGPwTcRmeOk3QD3X0rwSawCJhfcnROzIc4AnfSP3w==
+"@react-native-community/cli-tools@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-4.7.0.tgz#83d49277e7f56fef87bdfd0ba55d2cfa20190689"
+  integrity sha512-llNWJEWXhGMsaHLWoieraPeWuva3kRsIEPi8oRVTybyz82JjR71mN0OFs41o1OnAR6+TR9d5cJPN+mIOESugEA==
   dependencies:
     chalk "^3.0.0"
     lodash "^4.17.15"
     mime "^2.4.1"
     node-fetch "^2.6.0"
 
-"@react-native-community/cli-types@^4.6.3":
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-4.6.3.tgz#e431e895e4ddedd0e2c80c2f492af60dd13cc15a"
-  integrity sha512-76uXaqPV1m6zGmL+x/KGHfLZiVVbCvkI4KElnd1dVEsDrVVoAsJ0tvBad+GhHh/NtYU1VmtuJ/zcKnjWdVla1A==
+"@react-native-community/cli-types@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-4.7.0.tgz#871905753f8ff83cf10c48e8df3fdd63cd7667a0"
+  integrity sha512-Pw05Rsh/ENFs/Utv1SVRFfdMAn+W9yy1AOhyIKB36JX0Xw00sIZQDyZVsVfmaLSOpRpJ/qUdKWXB/WYV4XYELw==
 
 "@react-native-community/cli@^4.5.1":
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-4.6.3.tgz#8b906b8af87753a6bc580358ea17116a040d7e67"
-  integrity sha512-MqOvUyKfspzA/uUSQELouYDkS4hbqaCWG/Nc13/k+vwQnXjq2sJlVKZCrctV4IY33oKMr/S0LwyZiiiwhQ8GMg==
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-4.7.0.tgz#be692631356d14fd1ffe23f25b479dca9e8e7c95"
+  integrity sha512-DbpxcPC7lFCJ112dPXL4DBKh5TfH0QK2OTG7uEGjfsApT4c01Lae6OMTNSssXgXTcNJApqIT5a6GXK2vSE0CEQ==
   dependencies:
     "@hapi/joi" "^15.0.3"
-    "@react-native-community/cli-debugger-ui" "^4.6.3"
-    "@react-native-community/cli-tools" "^4.6.3"
-    "@react-native-community/cli-types" "^4.6.3"
+    "@react-native-community/cli-debugger-ui" "^4.7.0"
+    "@react-native-community/cli-tools" "^4.7.0"
+    "@react-native-community/cli-types" "^4.7.0"
     chalk "^3.0.0"
     command-exists "^1.2.8"
     commander "^2.19.0"
@@ -1464,9 +1472,9 @@ atob@^2.1.2:
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 babel-plugin-dynamic-import-node@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz#f00f507bdaa3c3e3ff6e7e5e98d90a7acab96f7f"
-  integrity sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
+  integrity sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
   dependencies:
     object.assign "^4.1.0"
 
@@ -1513,6 +1521,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-js@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.1.2.tgz#d6400cac1c4c660976d90d07a04351d89395f5e8"
+  integrity sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg=
+
 base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.2.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
@@ -1531,7 +1544,7 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-big-integer@^1.6.44:
+big-integer@^1.6.44, big-integer@^1.6.7:
   version "1.6.48"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
   integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
@@ -1548,12 +1561,26 @@ bmp-js@^0.1.0:
   resolved "https://registry.yarnpkg.com/bmp-js/-/bmp-js-0.1.0.tgz#e05a63f796a6c1ff25f4771ec7adadc148c07233"
   integrity sha1-4Fpj95amwf8l9Hcex62twUjAcjM=
 
+bplist-creator@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.0.7.tgz#37df1536092824b87c42f957b01344117372ae45"
+  integrity sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=
+  dependencies:
+    stream-buffers "~2.2.0"
+
 bplist-creator@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.0.8.tgz#56b2a6e79e9aec3fc33bf831d09347d73794e79c"
   integrity sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==
   dependencies:
     stream-buffers "~2.2.0"
+
+bplist-parser@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.1.1.tgz#d60d5dcc20cba6dc7e1f299b35d3e1f95dafbae6"
+  integrity sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=
+  dependencies:
+    big-integer "^1.6.7"
 
 bplist-parser@0.2.0:
   version "0.2.0"
@@ -1616,9 +1643,9 @@ buffer-from@^1.0.0:
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 buffer@^5.2.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.5.0.tgz#9c3caa3d623c33dd1c7ef584b89b88bf9c9bc1ce"
-  integrity sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -1761,9 +1788,9 @@ cli-truncate@^0.2.1:
     string-width "^1.0.1"
 
 cli-width@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
-  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
+  integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -1836,9 +1863,9 @@ colorette@^1.0.7:
   integrity sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg==
 
 command-exists@^1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
-  integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
+  integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
 
 commander@^2.19.0:
   version "2.20.3"
@@ -2017,9 +2044,9 @@ date-fns@^1.27.2:
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
 dayjs@^1.8.15:
-  version "1.8.24"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.24.tgz#2ef8a2ab9425eaf3318fe78825be1c571027488d"
-  integrity sha512-bImQZbBv86zcOWOq6fLg7r4aqMx8fScdmykA7cSh+gH1Yh8AM0Dbw0gHYrsOrza6oBBnkK+/OaR+UAa9UsMrDw==
+  version "1.8.25"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.25.tgz#d09a8696cee7191bc1289e739f96626391b9c73c"
+  integrity sha512-Pk36juDfQQGDCgr0Lqd1kw15w3OS6xt21JaLPE3lCfsEf8KrERGwDNwvK1tRjrjqFC0uZBJncT4smZQ4F+uV5g==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -2585,7 +2612,7 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-glob@^7.1.3:
+glob@7.1.6, glob@^7.1.3:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -3817,9 +3844,9 @@ mute-stream@0.0.7:
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
 nan@^2.12.1:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
-  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
+  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -4322,7 +4349,16 @@ please-upgrade-node@^3.2.0:
   dependencies:
     semver-compare "^1.0.0"
 
-plist@^3.0.1:
+plist@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/plist/-/plist-2.0.1.tgz#0a32ca9481b1c364e92e18dc55c876de9d01da8b"
+  integrity sha1-CjLKlIGxw2TpLhjcVch23p0B2os=
+  dependencies:
+    base64-js "1.1.2"
+    xmlbuilder "8.2.2"
+    xmldom "0.1.x"
+
+plist@3.0.1, plist@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.1.tgz#a9b931d17c304e8912ef0ba3bdd6182baf2e1f8c"
   integrity sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==
@@ -4368,11 +4404,11 @@ pretty-format@^24.7.0, pretty-format@^24.9.0:
     react-is "^16.8.4"
 
 pretty-format@^25.2.0:
-  version "25.3.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.3.0.tgz#d0a4f988ff4a6cd350342fdabbb809aeb4d49ad5"
-  integrity sha512-wToHwF8bkQknIcFkBqNfKu4+UZqnrLn/Vr+wwKQwwvPzkBfDDKp/qIabFqdgtoi5PEnM8LFByVsOrHoa3SpTVA==
+  version "25.4.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.4.0.tgz#c58801bb5c4926ff4a677fe43f9b8b99812c7830"
+  integrity sha512-PI/2dpGjXK5HyXexLPZU/jw5T9Q6S1YVXxxVxco+LIqzUFHXIbKZKdUVt7GcX7QUCr31+3fzhi4gN4/wUYPVxQ==
   dependencies:
-    "@jest/types" "^25.3.0"
+    "@jest/types" "^25.4.0"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
@@ -4624,9 +4660,9 @@ resolve-url@^0.2.1:
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
 resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
-  integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.16.1.tgz#49fac5d8bacf1fd53f200fa51247ae736175832c"
+  integrity sha512-rmAglCSqWWMrrBv/XM6sW0NuRFiKViw/W4d9EbC4pt+49H8JwHy+mcGmALTEg504AUDcLTvb1T2q3E9AnmY+ig==
   dependencies:
     path-parse "^1.0.6"
 
@@ -4866,6 +4902,15 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
+simple-plist@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-0.2.1.tgz#71766db352326928cf3a807242ba762322636723"
+  integrity sha1-cXZts1IyaSjPOoByQrp2IyJjZyM=
+  dependencies:
+    bplist-creator "0.0.7"
+    bplist-parser "0.1.1"
+    plist "2.0.1"
+
 simple-plist@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-1.1.0.tgz#8354ab63eb3922a054c78ce96c209c532e907a23"
@@ -4951,9 +4996,9 @@ source-map-resolve@^0.5.0:
     urix "^0.1.0"
 
 source-map-support@^0.5.16:
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
-  integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
+  version "0.5.18"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.18.tgz#f5f33489e270bd7f7d7e7b8debf283f3a4066960"
+  integrity sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -5365,6 +5410,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
+uuid@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+  integrity sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=
+
 uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -5518,6 +5568,11 @@ xml2js@^0.4.5:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
 
+xmlbuilder@8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
+  integrity sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=
+
 xmlbuilder@^9.0.7:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
@@ -5566,11 +5621,11 @@ yallist@^3.0.0, yallist@^3.0.3:
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yaml@^1.7.2:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.8.3.tgz#2f420fca58b68ce3a332d0ca64be1d191dd3f87a"
-  integrity sha512-X/v7VDnK+sxbQ2Imq4Jt2PRUsRsP7UcpSl3Llg6+NRRqWLIvxkMFYtH1FmvwNGYRKKPa+EPA4qDBlI9WVG1UKw==
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.9.2.tgz#f0cfa865f003ab707663e4f04b3956957ea564ed"
+  integrity sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==
   dependencies:
-    "@babel/runtime" "^7.8.7"
+    "@babel/runtime" "^7.9.2"
 
 yargs-parser@^11.1.1:
   version "11.1.1"


### PR DESCRIPTION
Fixes issue #51 by adding an argument-based system for defining bootsplash components.
Key files:
* `react-native.config.js` - defines the command for running
* `lib/generate.js` exports a function for running the generator for extensiblility
* `scripts/generate.js` now uses the exported version of generate
* `README.md` references the new CLI system

Also adding functionality to automatically add the storyboard to the ios Xcode package, and make it the launchscreen provider, addressing issue #85