### PR TITLE
Add support for custom notification actions

### DIFF
--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashActivity.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashActivity.java
@@ -25,15 +25,13 @@ public class RNBootSplashActivity extends AppCompatActivity {
     try {
       Intent intent = new Intent(this, getMainActivityClass());
       Bundle extras = getIntent().getExtras();
-      String action = getIntent().getAction();
 
       if (extras != null) {
         intent.putExtras(extras);
       }
-      if (Intent.ACTION_VIEW.equals(action)) {
-        intent.setAction(action);
-        intent.setData(getIntent().getData());
-      }
+
+      intent.setAction(getIntent().getAction());
+      intent.setData(getIntent().getData());
 
       startActivity(intent);
       finish();


### PR DESCRIPTION
Hello! 
Is any reason why you attach action and data only in case of intent's `ACTION_VIEW` action? This breaks intents that are come via [notification action](https://developer.android.com/training/notify-user/build-notification#Actions) press, so they get to the MainActivity without vital `action` identifier. 