### PR TITLE
Added Web Platform support (react-native-web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ This tool relies on the naming conventions that are used in the `/example` proje
 <PROJECT_ROOT>/ios/RNBootSplashExample/Images.xcassets/BootSplashLogo.imageset/bootsplash_logo.png
 <PROJECT_ROOT>/ios/RNBootSplashExample/Images.xcassets/BootSplashLogo.imageset/bootsplash_logo@2x.png
 <PROJECT_ROOT>/ios/RNBootSplashExample/Images.xcassets/BootSplashLogo.imageset/bootsplash_logo@3x.png
+
+<PROJECT_ROOT>/web/bootsplash_logo.png
+<PROJECT_ROOT>/web/bootsplash_logo-hires.png
+
 ```
 
 ### iOS
@@ -246,6 +250,105 @@ As Android will not create our main activity before launching the app, we need t
   </application>
 
 </manifest>
+```
+
+### WEB
+
+_⚠️ React Native Web Support is Experimental!_
+
+If you have opted in for the web support during the image generation process you should have `bootsplash_logo.png` and `bootsplash_logo-hires.png` in your `WEBROOT` directory.
+
+Edit `index.html` file to add bootsplkash on initial load.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    ...
+    <!-- Style -->
+    <style>
+      /* bootsplash related variables */
+      :root {
+        --bootsplash: url("bootsplash_logo.png");
+        --bootsplash-hires: url("bootsplash_logo-hires.png");
+        --bootsplash-color: #fff;
+      }
+
+      #bootsplash {
+        position: absolute;
+        display: block;
+        height: 100%;
+        width: 100%;
+        z-index: 99;
+        background-image: var(--bootsplash);
+        background-color: var(--bootsplash-color);
+        background-attachment: fixed;
+        background-size: auto 50%;
+        background-repeat: no-repeat;
+        background-position: center;
+      }
+
+      /* show bootsplash in the middle of the screen on portrait devices like phones. */
+      @media screen and (orientation: portrait) {
+        #bootsplash {
+          background-size: 50% auto;
+        }
+      }
+    </style>
+    ...
+  </head>
+
+  <body>
+    <!-- add a div for bootsplash to show up before your react-root -->
+    <div id="bootsplash"></div>
+    ...
+  </body>
+</html>
+```
+
+#### Optional:
+
+If you want a pulse effect while the bootsplash is active, you can use a keyframe animation.
+
+```css
+/* if you want a pulse effect on bootsplash logo */
+:root {
+  --bootsplash-pulse-opacity: 0.33;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 0;
+  }
+
+  50% {
+    opacity: var(--bootsplash-pulse-opacity);
+  }
+
+  100% {
+    opacity: 0;
+  }
+}
+
+#bootsplash::before {
+  content: "";
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: var(--bootsplash-color);
+  animation: pulse 1s infinite;
+  z-index: 100;
+}
+```
+
+to show hires version on hi dpi screens:
+
+```css
+@media (min-resolution: 192dpi) {
+  #bootsplash {
+    background-image: var(--bootsplash-hires);
+  }
+}
 ```
 
 ## API

--- a/index.js
+++ b/index.js
@@ -1,11 +1,43 @@
-import { NativeModules } from "react-native";
+import { NativeModules, Platform } from "react-native";
 const { RNBootSplash } = NativeModules;
 
 export function hide(config = {}) {
+  if (!NativeModules.RNBootSplash && Platform.OS === "web") {
+    const duration = config.duration || 0;
+    const element = document.getElementById("bootsplash");
+    if (duration === 0) {
+      element.style.display = "none";
+      element.style.opacity = 0;
+      return;
+    }
+    const listener = (event) => {
+      if (event.target !== element) return;
+      element.style.display = "none";
+      element.removeEventListener("transitionend", listener);
+    };
+    element.addEventListener("transitionend", listener);
+    element.style.transition = `opacity ${duration}ms ease-in-out`;
+    element.style.opacity = 0;
+    return;
+  }
   RNBootSplash.hide({ duration: 0, ...config }.duration);
 }
 
 export function show(config = {}) {
+  if (!NativeModules.RNBootSplash && Platform.OS === "web") {
+    const duration = config.duration || 0;
+    const element = document.getElementById("bootsplash");
+    if (duration === 0) {
+      element.style.display = "block";
+      element.style.opacity = 1;
+      return;
+    }
+    element.style.display = "block";
+    element.offsetHeight;
+    element.style.transition = `opacity ${duration}ms ease-in-out`;
+    element.style.opacity = 1;
+    return;
+  }
   RNBootSplash.show({ duration: 0, ...config }.duration);
 }
 

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -232,6 +232,30 @@ const questions = [
     max: 1000,
   },
   {
+    name: "webSetup",
+    type: "confirm",
+    message: "Do you want to setup bootsplash for react-native-web?",
+    initial: false,
+  },
+  {
+    name: "webPath",
+    type: (prev) => (prev ? "text" : null),
+    initial: (prev, values) => path.join(values.projectPath, "web"),
+    message: `The path to your web dist folder (ie. where ${chalk.bold(
+      "index.html",
+    )} resides)`,
+
+    validate: (value) => {
+      if (!fs.existsSync(value)) {
+        return `Invalid web path. The directory ${chalk.bold(
+          value,
+        )} could not be found.`;
+      }
+
+      return true;
+    },
+  },
+  {
     name: "confirmation",
     type: "confirm",
     message:
@@ -246,6 +270,8 @@ async function generate({
   iconPath,
   backgroundColor,
   iconWidth: w1,
+  webSetup,
+  webPath,
   confirmation,
 }) {
   if (!projectPath || !assetsPath || !iconPath || !w1 || !confirmation) {
@@ -309,6 +335,18 @@ async function generate({
     );
   } else {
     log(`No ${iosImagesPath} directory found. Skipping iOS generation…`);
+  }
+
+  if (webSetup) {
+    if (fs.existsSync(webPath)) {
+      imageMap.push([path.join(webPath, logoFileName + ".png"), [w3, h(w3)]]);
+      imageMap.push([
+        path.join(webPath, logoFileName + "-hires.png"),
+        [w4, h(w4)],
+      ]);
+    } else {
+      log(`No ${webPath} directory found. Skipping web generation…`);
+    }
   }
 
   imageMap.push(


### PR DESCRIPTION
Added support so hide and show methods can be called from JavaScript with desired results. 

The 'native' setup part for web is mostly on the entrypoint (index.html) so I've added instruction in the README.md. 

I mostly done this for my personal project. Let me know anything else needs to be done to make it 'merge material' or web is out of scope for this project. 

Thanks. 