### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/RNBootSplash.podspec
+++ b/RNBootSplash.podspec
@@ -3,7 +3,7 @@ package = JSON.parse(File.read('./package.json'))
 
 Pod::Spec.new do |s|
   s.name            = "RNBootSplash"
-  s.dependency        "React"
+  s.dependency        "React-Core"
 
   s.version         = package["version"]
   s.license         = package["license"]


### PR DESCRIPTION
# Summary
Latest Xcode 12 fails to build while without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. For more details please check: facebook/react-native#29633 

### What's required for testing (prerequisites)?
Xcode 12 for testing

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅  |
| Android |    ❌     |

## Checklist
- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
