### PR TITLE
Allow extending with custom activity class [Android]

### DIFF
--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashActivity.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashActivity.java
@@ -9,7 +9,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 public class RNBootSplashActivity extends AppCompatActivity {
 
-  private Class<?> getMainActivityClass() throws Exception {
+  protected Class<?> getMainActivityClass() throws Exception {
     final Context appContext = getApplicationContext();
     final Package appPackage = appContext.getClass().getPackage();
     assert appPackage != null;


### PR DESCRIPTION
# Summary
Needed to redirect to custom activity package/name

In order to maintain compatibility with previous versions of the app, we need to use an activity-alias. In that case we the logic to get the main activity to redirect will fail as the activity-alias doesn't create a backing class.


## Test Plan

No user-facing changes

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ n/a] I updated the typed files (TS and Flow)
- [ n/a] I added a sample use of the API in the example project (`example/App.js`)
