### PR TITLE
[android] Use activity as context instead of application

### DIFF
--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
@@ -3,7 +3,6 @@ package com.zoontek.rnbootsplash;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.app.Activity;
-import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.AccelerateInterpolator;
@@ -62,9 +61,8 @@ public class RNBootSplashModule extends ReactContextBaseJavaModule implements Li
   }
 
   private static LinearLayout getLayout(@NonNull Activity activity, LayoutParams params) {
-    Context context = activity.getApplicationContext();
-    LinearLayout layout = new LinearLayout(context);
-    View view = new View(context);
+    LinearLayout layout = new LinearLayout(activity);
+    View view = new View(activity);
 
     view.setBackgroundResource(mDrawableResId);
     layout.setId(R.id.bootsplash_layout_id);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Fixes #198

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

### What's required for testing (prerequisites)?

Use https://github.com/slaci/RnBootsplashExample for testing.

### What are the steps to reproduce (after prerequisites)?

Just open the app and see which logo is shown. A logo with "dark" label should be always visible regardless of the phone's setting. In the example app, the logo will be hidden after 3 seconds after app start.

Android devices which do not support night mode (maybe < 10) will continue to show the light mode logo as before (tested in api level 26 emulator). It only fixes situations when different variant of native drawables are used (not only dark mode exists, it is possible to create images for eg. landscape orientation too).

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
