### PR TITLE
feat: forward intent type to mainActivity

### DIFF
--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashActivity.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashActivity.java
@@ -26,6 +26,7 @@ public class RNBootSplashActivity extends AppCompatActivity {
       intentCopy.putExtras(intent);
       intentCopy.setData(intent.getData());
       intentCopy.setAction(intent.getAction());
+      intentCopy.setType(intent.getType());
 
       startActivity(intentCopy);
       finish();


### PR DESCRIPTION
# Summary


### What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
The intent type was not being forwarded to the MainActivity. This was a problem when I was trying to receive sharing intents in my RN app which uses this lovely library. 

### What is the feature? (if applicable)
Forward the intent type to MainActivity.

### How did you implement the solution?
I used the intent methods 'setType' and 'getType'

### What areas of the library does it impact?
It impacts the intent forwarding to MainActivity


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Android device and/or emulator, logger

### What are the steps to reproduce (after prerequisites)?
Log incoming activity that a type (the example I was using was receiving a Send activity with type 'text'). Before this pr the type will be null. After this pr, the type will be the correct MIME type ('text' or 'image') etc. More information https://developer.android.com/reference/android/content/Intent#getType() and https://developer.android.com/reference/android/content/Intent#setType(java.lang.String)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅    | (android only issue)

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
