### PR TITLE
fix: only forward non-null intent type to MainActivity

### DIFF
--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashActivity.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashActivity.java
@@ -26,7 +26,11 @@ public class RNBootSplashActivity extends AppCompatActivity {
       intentCopy.putExtras(intent);
       intentCopy.setData(intent.getData());
       intentCopy.setAction(intent.getAction());
-      intentCopy.setType(intent.getType());
+      
+      String type = intent.getType();
+      if (type != null) { 
+        intentCopy.setType(type);
+      }
 
       startActivity(intentCopy);
       finish();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Explain the **motivation** for making this change: here are some points to help you:

* In #205 I forwarded the intent type to MainActivity without checking if the type was null. Forwarding a 'null' type to MainActivity breaks [React-Navigation deeplinking](https://github.com/zoontek/react-native-bootsplash/pull/205#issuecomment-779829726 (thanks @exentrich for heads up!)
). So this pr checks if type is null and only sets it if it is non-null.

## Test Plan

Without checking for null type, (ie as of #205 ) `adb shell am start -W -a android.intent.action.VIEW -d [deeplink] [packagename]` does not work with React-Navigation deeplinks

With this pr `adb shell am start -W -a android.intent.action.VIEW -d [deeplink] [packagename]` does work for React-Navigation deeplinks

### What's required for testing (prerequisites)?

App with deeplinks configured by React-Navigations

### What are the steps to reproduce (after prerequisites)?

Build app, trigger a deeplink (`adb shell am start -W -a android.intent.action.VIEW -d [deeplink] [packagename]`), verify that it works

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅   |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
