### PR TITLE
 Update ReScript bindings for 3.1

### DIFF
--- a/ReactNativeBootsplash.res
+++ b/ReactNativeBootsplash.res
@@ -1,10 +1,10 @@
 type config = {fade: bool}
 
 @bs.module("react-native-bootsplash") @bs.scope("default")
-external hide: config => unit = "hide"
+external hide: config => Js.Promise.t<unit> = "hide"
 
 @bs.module("react-native-bootsplash") @bs.scope("default")
-external show: config => unit = "show"
+external show: config => Js.Promise.t<unit> = "show"
 
 // Note that this binding requires BuckleScript >= 8.2.0
 type visibilityStatus = [#visible | #hidden | #transitioning]
@@ -12,10 +12,22 @@ type visibilityStatus = [#visible | #hidden | #transitioning]
 @bs.module("react-native-bootsplash") @bs.scope("default")
 external getVisibilityStatus: unit => Js.Promise.t<visibilityStatus> = "getVisibilityStatus"
 /*
- ## Usage
+## Usage
 
- ```re
- ReactNativeBootSplash.hide({fade: true});
- ReactNativeBootSplash.show({fade: false});
- ```
- */
+```rescript
+ ReactNativeBootsplash.hide({fade: true})->ignore
+ ReactNativeBootSplash.show({fade: false})->ignore
+```
+
+Or
+
+ ```rescript
+ReactNativeBootsplash.hide({fade: true})->Js.Promise.then_(() => {
+  Js.log("RN BootSplash: fading is over")
+  Js.Promise.resolve()
+}, _)->Js.Promise.catch(error => {
+  Js.log(("RN BootSplash: cannot hide splash", error))
+  Js.Promise.resolve()
+}, _)->ignore
+```
+*/


### PR DESCRIPTION
Please poke me next time if you add features that need bindings :)

# Summary

Title is explicit

## Test Plan

Tested locally on my project

### What's required for testing (prerequisites)?

Some trust in @MoOx 

### What are the steps to reproduce (after prerequisites)?

Currently we cannot not use promise based API with ReScript 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] ~~I updated the typed files (TS and Flow)~~
- [x] I added a sample use of the API in the example project (~~`example/App.js`~~ in the bindings themselves)
