### PR TITLE
Feat/flavor android option assets gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Options:
   --background-color <color>  color used as launch screen background (in hexadecimal format) (default: "#fff")
   --logo-width <width>        logo width at @1x (in dp - we recommand approximately ~100) (default: 100)
   --assets-path [path]        path to your static assets directory (useful to require the logo file in JS)
+  --flavor <flavor>           [android only] flavor build variant (results \in a android resource path other than 'main')
   -h, --help                  output usage information
 ```
 
@@ -121,6 +122,7 @@ yarn react-native generate-bootsplash assets/bootsplash_logo_original.png \
   --background-color=F5FCFF \
   --logo-width=100 \
   --assets-path=assets
+  --flavor=main
 ```
 
 ![](https://raw.githubusercontent.com/zoontek/react-native-bootsplash/master/docs/cli_tool.png?raw=true)
@@ -147,6 +149,22 @@ assets/bootsplash_logo@1,5x.png
 assets/bootsplash_logo@2x.png
 assets/bootsplash_logo@3x.png
 assets/bootsplash_logo@4x.png
+```
+
+_[android-only]_
+
+If `--flavor` was specified, the `main folder` is changed for `flavor name`
+
+sample with `--flavor=free`:
+
+```
+android/app/src/free/res/drawable/bootsplash.xml
+android/app/src/free/res/values/colors.xml (creation and edition)
+android/app/src/free/res/mipmap-hdpi/bootsplash_logo.png
+android/app/src/free/res/mipmap-mdpi/bootsplash_logo.png
+android/app/src/free/res/mipmap-xhdpi/bootsplash_logo.png
+android/app/src/free/res/mipmap-xxhdpi/bootsplash_logo.png
+android/app/src/free/res/mipmap-xxxhdpi/bootsplash_logo.png
 ```
 
 ### iOS

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -25,11 +25,16 @@ module.exports = {
           description:
             "path to your static assets directory (useful to require the logo file in JS)",
         },
+        {
+          name: "--flavor <flavor>",
+          description:
+            "[android only] flavor build variant (results in a android resource path other than 'main')",
+        },
       ],
       func: (
         [logoPath],
         { project: { android, ios } },
-        { backgroundColor, logoWidth, assetsPath },
+        { backgroundColor, logoWidth, assetsPath, flavor },
       ) => {
         const workingDirectory =
           process.env.INIT_CWD || process.env.PWD || process.cwd();
@@ -45,6 +50,7 @@ module.exports = {
           assetsPath: assetsPath
             ? path.resolve(workingDirectory, assetsPath)
             : undefined,
+          flavor,
         }).catch((error) => {
           console.error(error);
         });

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -132,6 +132,7 @@ export const generate = async ({
   backgroundColor,
   logoWidth,
   assetsPath,
+  flavor,
 }: {
   android: {
     sourceDir: string;
@@ -146,6 +147,7 @@ export const generate = async ({
   backgroundColor: string;
   logoWidth: number;
   assetsPath?: string;
+  flavor?: string;
 }) => {
   if (!isValidHexadecimal(backgroundColor)) {
     throw new Error(
@@ -216,7 +218,12 @@ export const generate = async ({
       ? path.resolve(android.sourceDir, android.appName)
       : path.resolve(android.sourceDir); // @react-native-community/cli 2.x & 3.x support
 
-    const resPath = path.resolve(appPath, "src", "main", "res");
+    const resPath = path.resolve(
+      appPath,
+      "src",
+      `${flavor ? flavor : "main"}`,
+      "res",
+    );
     const drawablePath = path.resolve(resPath, "drawable");
     const valuesPath = path.resolve(resPath, "values");
 


### PR DESCRIPTION
# Summary

Added support for android flavor assets option. This is useful for multi flavors support with differents bootsplash assets.

## Test Plan

You can test with https://github.com/zoontek/react-native-bootsplash#assets-generation commands including `--flavor` variant

full sample with `--flavor=free`:
```
yarn react-native generate-bootsplash assets/bootsplash_logo_original.png \
  --background-color=F5FCFF \
  --logo-width=100 \
  --assets-path=assets
  --flavor=free
```

Result:
```
android/app/src/free/res/drawable/bootsplash.xml
android/app/src/free/res/values/colors.xml (creation and edition)
android/app/src/free/res/mipmap-hdpi/bootsplash_logo.png
android/app/src/free/res/mipmap-mdpi/bootsplash_logo.png
android/app/src/free/res/mipmap-xhdpi/bootsplash_logo.png
android/app/src/free/res/mipmap-xxhdpi/bootsplash_logo.png
android/app/src/free/res/mipmap-xxxhdpi/bootsplash_logo.png
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a terminal
- [ ] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
