### PR TITLE
fix(android): prevent set background before call RNBootsplash.init

### DIFF
--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
@@ -63,8 +63,12 @@ public class RNBootSplashModule extends ReactContextBaseJavaModule implements Li
   private static LinearLayout getLayout(@NonNull Activity activity, LayoutParams params) {
     LinearLayout layout = new LinearLayout(activity);
     View view = new View(activity);
+    // if `init` method was not called the mDrawableResId has the default value
+    // setBackgroundResource will trigger an error when the resId is -1 and the app will crash
+    if(mDrawableResId != -1){
+      view.setBackgroundResource(mDrawableResId);
+    }
 
-    view.setBackgroundResource(mDrawableResId);
     layout.setId(R.id.bootsplash_layout_id);
     layout.setLayoutTransition(null);
     layout.setOrientation(LinearLayout.VERTICAL);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

When the developer tries manually reload the app (pressing R on terminal or using the DevMenu) without calling `RNBootsplash.init` on `MainActivity`, it crashes the app.


## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
