### PR TITLE
Warn if RNBootSplash is initialised before rootViewController is set

### DIFF
--- a/ios/RNBootSplash.m
+++ b/ios/RNBootSplash.m
@@ -1,6 +1,7 @@
 #import "RNBootSplash.h"
 
 #import <React/RCTBridge.h>
+#import <React/RCTLog.h>
 #import <React/RCTUtils.h>
 
 static NSMutableArray<RNBootSplashTask *> *_taskQueue = nil;
@@ -41,6 +42,13 @@ RCT_EXPORT_MODULE();
 
 + (void)initWithStoryboard:(NSString * _Nonnull)storyboardName
                   rootView:(RCTRootView * _Nonnull)rootView {
+  UIViewController *rootVC = RCTPresentedViewController();
+
+  if (!rootVC) {
+    RCTLogError(@"RCTBootSplash initialized before rootViewController set");
+    return;
+  }
+
   _rootView = rootView;
   _status = RNBootSplashStatusVisible;
   _storyboardName = storyboardName;
@@ -57,9 +65,7 @@ RCT_EXPORT_MODULE();
   [_splashVC setModalPresentationStyle:UIModalPresentationOverFullScreen];
   [_splashVC setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
 
-  [RCTPresentedViewController() presentViewController:_splashVC
-                                             animated:false
-                                           completion:^{
+  [rootVC presentViewController:_splashVC animated:false completion:^{
     [_rootView.loadingView removeFromSuperview];
     _rootView.loadingView = nil;
 


### PR DESCRIPTION
# Summary

If the app's window has not been configured with a root view controller or made key, `RCTPresentedViewController()` returns `nil`, and RNBootSplash is left in an inconsistent state where the splash view cannot be hidden. If this happens, log an error to help users debug the issue.

<img src="https://user-images.githubusercontent.com/147686/118295440-dd49b500-b4a9-11eb-8d36-77c8c3e1c00e.png" width="325">

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] ~~I added the documentation in `README.md`~~
- [ ] ~~I mentioned this change in `CHANGELOG.md`~~ (N/A)
- [ ] ~~I updated the typed files (TS and Flow)~~ (N/A)
- [ ] ~~I added a sample use of the API in the example project (`example/App.js`)~~ (N/A)
