### PR TITLE
README: prevent react-native-screens crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ public class MainActivity extends ReactActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState); // or super.onCreate(null) with react-native-screens
-    RNBootSplash.init(R.drawable.bootsplash, MainActivity.this); // Display the generated bootsplash.xml drawable over our MainActivity
+    RNBootSplash.init(R.drawable.bootsplash, MainActivity.this); // display the generated bootsplash.xml drawable over our MainActivity
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -212,12 +212,8 @@ public class MainActivity extends ReactActivity {
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
-    // If using react-native-screens, you must pass null to super.onCreate to prevent a crash.
-    // If not using react-native-screens, change `null` to `savedInstanceState` in this line.
-    super.onCreate(null); 
-  
-    // Display the generated bootsplash.xml drawable over our MainActivity
-    RNBootSplash.init(R.drawable.bootsplash, MainActivity.this); 
+    super.onCreate(savedInstanceState); // or super.onCreate(null) with react-native-screens
+    RNBootSplash.init(R.drawable.bootsplash, MainActivity.this); // Display the generated bootsplash.xml drawable over our MainActivity
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -212,8 +212,12 @@ public class MainActivity extends ReactActivity {
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    RNBootSplash.init(R.drawable.bootsplash, MainActivity.this); // <- display the generated bootsplash.xml drawable over our MainActivity
+    // If using react-native-screens, you must pass null to super.onCreate to prevent a crash.
+    // If not using react-native-screens, change `null` to `savedInstanceState` in this line.
+    super.onCreate(null); 
+  
+    // Display the generated bootsplash.xml drawable over our MainActivity
+    RNBootSplash.init(R.drawable.bootsplash, MainActivity.this); 
   }
 ```
 


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

To prevent a crash when using `react-native-screens`, you must pass `null` to `super.onCreate` in `MainActivity`. [Reference](https://github.com/software-mansion/react-native-screens#android)

This PR updates the Android example in the README to pass `null` to `super.onCreate`, because I assume most React Native apps use `react-native-screens`. Without this change, a developer might copy the `react-native-bootsplash` example code into their app, accidentally overwriting the `super.onCreate(null)` call that is needed to prevent the crash.

## Test Plan

Not sure if a test plan is necessary for this change. If it is let me know and I will attempt to fill in this section.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md` **N/A**
- [ ] I updated the typed files (TS and Flow) **N/A**
- [ ] I added a sample use of the API in the example project (`example/App.js`).  **N/A**
