### PR TITLE
Add layout support for Android

### DIFF
--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplash.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplash.java
@@ -3,11 +3,16 @@ package com.zoontek.rnbootsplash;
 import android.app.Activity;
 
 import androidx.annotation.DrawableRes;
+import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 
 public class RNBootSplash {
 
   public static void init(final @DrawableRes int drawableResId, @NonNull final Activity activity) {
-    RNBootSplashModule.init(drawableResId, activity);
+    RNBootSplashModule.init(drawableResId, false, activity);
+  }
+
+  public static void initLayout(final @LayoutRes int layoutResId, @NonNull final Activity activity) {
+    RNBootSplashModule.init(layoutResId, true, activity);
   }
 }


### PR DESCRIPTION
**Will fill rest of this out shortly**

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR adds support for showing a splash screen on Android using a layout ID that will be inflated, rather than a drawable.

This allows for more complex and freedom with splash screen design (our app required more specific artwork than a single image in the middle of the screen).

The PR adds a new `initLayout` method to the Android API that takes in a layout resource ID.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
