### PR TITLE
docs(v4): mention API21 possible but weak support, grammar

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 ## What's new
 
-- The drop of Android < 6 and iOS < 11
+- The drop of Android < 6 and iOS < 11 (Android 5 is *possible* but the AndroidX library offers only the most basic features on Android 5)
 - A switch to [AndroidX splashscreen library](https://developer.android.com/jetpack/androidx/releases/core#core-splashscreen-1.0.0-alpha02) to fully support Android 12
 - The removal of the `show` method
 - The `hide` method cannot reject anymore
@@ -89,7 +89,7 @@ For `android/app/src/main/AndroidManifest.xml`:
       android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
       android:launchMode="singleTask"
       android:windowSoftInputMode="adjustResize"
-      android:exported="true">
+      android:exported="true"> <!-- note the new "exported" element needed for API31 -->
 +     <intent-filter>
 +         <action android:name="android.intent.action.MAIN" />
 +         <category android:name="android.intent.category.LAUNCHER" />

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Don't forget going into the `ios` directory to execute a `pod install`.
 
 ## 🆘 Manual linking
 
-Because this package targets React Native 0.65.0+, you will probably don't need to link it manually. Otherwise if it's not the case, follow this additional instructions:
+Because this package targets React Native 0.65.0+, you probably don't need to link it manually. But if you have a special case, follow these additional instructions:
 
 <details>
   <summary><b>👀 See manual linking instructions</b></summary>
@@ -206,7 +206,7 @@ Set the `BootSplash.storyboard` as launch screen file:
 buildscript {
   ext {
     buildToolsVersion = "30.0.2"
-    minSdkVersion = 23 // <- set at least 23
+    minSdkVersion = 23 // <- AndroidX splashscreen has "theme switch only" support for 21, but 23 is best
     compileSdkVersion = 31 // <- set at least 31
     targetSdkVersion = 31 // <- set at least 31
 
@@ -367,7 +367,7 @@ function App() {
 
 ### Testing with Jest
 
-Testing code which uses this library required some setup since we need to mock the native methods.
+Testing code which uses this library requires some setup since we need to mock the native methods.
 
 To add the mocks, create a file _jest/setup.js_ (or any other file name) containing the following code:
 


### PR DESCRIPTION

Leaving the build.gradle alone, this is just tiny grammar tweaks, and mentioning API21 per #275 

I also specifically called out the `android:exported` need since that hasn't even landed on the react-native template yet and people may be unaware - I've been busy patching it in other places and most people are unaware...  https://github.com/facebook/react-native/pull/32540