### PR TITLE
Add SVG instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,18 +122,15 @@ Options:
   -h, --help                  output usage information
 ```
 
-#### Usage with SVGs
+#### Usage with SVG
 
-Unfortunately no current node-based image manipulation libraries have first class support for SVGs (see [this discussion](https://github.com/zoontek/react-native-bootsplash/issues/313#issuecomment-1030277234)), so it may be necessary to use `librsvg`. On macOS, you can install it with `brew install librsvg`.
+You might want to use SVG as input file. For that, you can install a CLI tool to convert your logo first:
 
-After installation, creating a boostplash logo is simple:
-
-```bash
-# Create a large PNG with generous leeway for 4x Android xxxhdpi devices
-rsvg-convert -w 800 assets/bootsplash_logo.svg > assets/bootsplash_logo.png
-react-native generate-bootsplash assets/bootsplash_logo.png
-# Optionally, clean up the PNG
-rm assets/bootsplash_logo.png
+```shell
+$ brew install librsvg # available on macOS
+$ rsvg-convert -w 3000 bootsplash_logo.svg bootsplash_logo.png # create a large PNG with generous leeway for 4x Android xxxhdpi devices
+$ react-native generate-bootsplash bootsplash_logo.png
+$ rm bootsplash_logo.png # optionally, clean up the PNG
 ```
 
 #### Full command usage example

--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ Options:
   -h, --help                  output usage information
 ```
 
+#### Usage with SVGs
+
+Unfortunately no current node-based image manipulation libraries have first class support for SVGs (see [this discussion](https://github.com/zoontek/react-native-bootsplash/issues/313#issuecomment-1030277234)), so it may be necessary to use `librsvg`. On macOS, you can install it with `brew install librsvg`.
+
+After installation, creating a boostplash logo is simple:
+
+```bash
+# Create a large PNG with generous leeway for 4x Android xxxhdpi devices
+rsvg-convert -w 800 assets/bootsplash_logo.svg > assets/bootsplash_logo.png
+react-native generate-bootsplash assets/bootsplash_logo.png
+# Optionally, clean up the PNG
+rm assets/bootsplash_logo.png
+```
+
 #### Full command usage example
 
 ```bash


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Adds SVG instructions to README as per out conversation here: https://github.com/zoontek/react-native-bootsplash/issues/313#issuecomment-1030285259

## Test Plan

Not needed.

### What's required for testing (prerequisites)?

N/A

### What are the steps to reproduce (after prerequisites)?

N/A

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [X] I added a sample use of the API in the example project (`example/App.tsx`)
