### PR TITLE
Docs: Add `-o` on Using an SVG section

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ You might want to use SVG as input file. For that, you can install a CLI tool to
 
 ```bash
 $ brew install librsvg # available on macOS
-$ rsvg-convert -w 3000 bootsplash_logo.svg bootsplash_logo.png # create a large PNG with generous leeway for 4x Android xxxhdpi devices
+$ rsvg-convert -w 3000 bootsplash_logo.svg -o bootsplash_logo.png # create a large PNG with generous leeway for 4x Android xxxhdpi devices
 $ react-native generate-bootsplash bootsplash_logo.png
 $ rm bootsplash_logo.png # optionally, clean up the PNG
 ```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Prevent `Multiple SVG files are only allowed for PDF and (E)PS output.` when generating PNG from SVG file.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
