### PR TITLE
feat: update androidx.core:core-splashscreen to 1.0.0-beta02

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,7 +3,7 @@
 ## What's new
 
 - The drop of Android < 6 and iOS < 11 (Android 5 is _possible_ but only displays the background color)
-- A switch to [AndroidX splashscreen library](https://developer.android.com/jetpack/androidx/releases/core#core-splashscreen-1.0.0-beta01) to fully support Android 12
+- A switch to [AndroidX splashscreen library](https://developer.android.com/jetpack/androidx/releases/core#core-splashscreen-1.0.0-beta02) to fully support Android 12
 - The removal of the `show` method
 - The `hide` method cannot reject anymore
 - The switch to `RCTRootView` only on iOS (removed usage of `UIViewController`)
@@ -40,7 +40,7 @@ dependencies {
   // …
 
   implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
-+ implementation "androidx.core:core-splashscreen:1.0.0-beta01"
++ implementation "androidx.core:core-splashscreen:1.0.0-beta02"
 ```
 
 For `android/app/src/main/res/values/styles.xml`:

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ dependencies {
   // …
 
   implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
-  implementation "androidx.core:core-splashscreen:1.0.0-beta01" // Add this line
+  implementation "androidx.core:core-splashscreen:1.0.0-beta02" // Add this line
 
   // …
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,5 +49,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+" // From node_modules
-    implementation "androidx.core:core-splashscreen:${safeExtGet("androidXSplashScreenVersion", "1.0.0-beta01")}"
+    implementation "androidx.core:core-splashscreen:${safeExtGet("androidXSplashScreenVersion", "1.0.0-beta02")}"
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -268,7 +268,7 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
-    implementation "androidx.core:core-splashscreen:1.0.0-beta01"
+    implementation "androidx.core:core-splashscreen:1.0.0-beta02"
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.fbjni'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Hi 👋

There is a new version of androidx.core:core-splashscreen out.
I didn't test the example app, but I tested my own apps and it seems to be working fine.

