### PR TITLE
feature: Implement custom fade out duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ public class MainActivity extends ReactActivity {
 #### Method type
 
 ```ts
-type hide = (config?: { fade?: boolean }) => Promise<void>;
+type hide = (config?: { fade?: boolean, duration?: boolean }) => Promise<void>;
 ```
 
 #### Usage
@@ -319,7 +319,8 @@ type hide = (config?: { fade?: boolean }) => Promise<void>;
 import RNBootSplash from "react-native-bootsplash";
 
 RNBootSplash.hide(); // immediate
-RNBootSplash.hide({ fade: true }); // fade
+RNBootSplash.hide({ fade: true }); // fade with 220ms default duration
+RNBootSplash.hide({ fade: true, duration: 500 }); // fade with custom duration
 ```
 
 ### getVisibilityStatus()
@@ -353,7 +354,7 @@ function App() {
     };
 
     init().finally(async () => {
-      await RNBootSplash.hide({ fade: true });
+      await RNBootSplash.hide({ fade: true, duration: 500 });
       console.log("Bootsplash has been hidden successfully");
     });
   }, []);

--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ public class MainActivity extends ReactActivity {
 type hide = (config?: { fade?: boolean, duration?: boolean }) => Promise<void>;
 ```
 
+Note: Only durations above 220ms are visually noticeable. Smaller values will be ignored and the default duration will be used.
+
 #### Usage
 
 ```js

--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModule.java
@@ -29,7 +29,6 @@ import java.util.TimerTask;
 public class RNBootSplashModule extends ReactContextBaseJavaModule {
 
   public static final String NAME = "RNBootSplash";
-  private static final int ANIMATION_DURATION = 220;
 
   private enum Status {
     VISIBLE,
@@ -44,6 +43,7 @@ public class RNBootSplashModule extends ReactContextBaseJavaModule {
   private static Status mStatus = Status.HIDDEN;
   private static boolean mShouldFade = false;
   private static boolean mShouldKeepOnScreen = true;
+  private static int mAnimationDuration;
 
   public RNBootSplashModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -80,8 +80,8 @@ public class RNBootSplashModule extends ReactContextBaseJavaModule {
         splashScreenView
           .animate()
           // Crappy hack to avoid automatic layout transitions
-          .setDuration(mShouldFade ? ANIMATION_DURATION: 0)
-          .setStartDelay(mShouldFade ? 0 : ANIMATION_DURATION)
+          .setDuration(mShouldFade ? mAnimationDuration: 0)
+          .setStartDelay(mShouldFade ? 0 : mAnimationDuration)
           .alpha(0.0f)
           .setInterpolator(new AccelerateInterpolator())
           .setListener(new AnimatorListenerAdapter() {
@@ -151,14 +151,15 @@ public class RNBootSplashModule extends ReactContextBaseJavaModule {
               timer.cancel();
               clearPromiseQueue();
             }
-          }, ANIMATION_DURATION);
+          }, mAnimationDuration);
         }
       }
     });
   }
 
   @ReactMethod
-  public void hide(final boolean fade, final Promise promise) {
+  public void hide(final boolean fade, final int fadeDuration, final Promise promise) {
+    mAnimationDuration = fadeDuration;
     mPromiseQueue.push(promise);
     hideAndResolveAll(fade);
   }

--- a/ios/RNBootSplash.m
+++ b/ios/RNBootSplash.m
@@ -85,6 +85,7 @@ RCT_EXPORT_MODULE();
 
 RCT_REMAP_METHOD(hide,
                  hideWithFade:(BOOL)fade
+                 fadeWithDuration:(NSInteger)fadeDuration
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
   if (_resolverQueue == nil)
@@ -104,7 +105,7 @@ RCT_REMAP_METHOD(hide,
     _isTransitioning = true;
 
     [UIView transitionWithView:_rootView
-                      duration:0.220
+                      duration:fadeDuration / 1000.0
                        options:UIViewAnimationOptionTransitionCrossDissolve
                     animations:^{
       _rootView.loadingView.hidden = YES;

--- a/ios/RNBootSplash.m
+++ b/ios/RNBootSplash.m
@@ -85,7 +85,7 @@ RCT_EXPORT_MODULE();
 
 RCT_REMAP_METHOD(hide,
                  hideWithFade:(BOOL)fade
-                 fadeWithDuration:(NSInteger)fadeDuration
+                 duration:(NSInteger)duration
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
   if (_resolverQueue == nil)
@@ -105,7 +105,7 @@ RCT_REMAP_METHOD(hide,
     _isTransitioning = true;
 
     [UIView transitionWithView:_rootView
-                      duration:fadeDuration / 1000.0
+                      duration:duration / 1000.0
                        options:UIViewAnimationOptionTransitionCrossDissolve
                     animations:^{
       _rootView.loadingView.hidden = YES;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-bootsplash",
-  "version": "4.3.3",
+  "version": "4.4.0",
   "license": "MIT",
   "description": "Display a bootsplash on your app starts. Hide it when you want.",
   "author": "Mathieu Acthernoene <zoontek@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-bootsplash",
-  "version": "4.4.0",
+  "version": "4.3.3",
   "license": "MIT",
   "description": "Display a bootsplash on your app starts. Hide it when you want.",
   "author": "Mathieu Acthernoene <zoontek@gmail.com>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,18 @@
 import { NativeModules } from "react-native";
 
 export type VisibilityStatus = "visible" | "hidden" | "transitioning";
-export type Config = { fade?: boolean };
+export type Config = { fade?: boolean, duration?: number };
 
 const NativeModule: {
-  hide: (fade: boolean) => Promise<true>;
+  hide: (fade: boolean, duration: number) => Promise<true>;
   getVisibilityStatus: () => Promise<VisibilityStatus>;
 } = NativeModules.RNBootSplash;
 
 export function hide(config: Config = {}): Promise<void> {
-  return NativeModule.hide({ fade: false, ...config }.fade).then(() => {});
+  return NativeModule.hide(
+    { fade: false, ...config }.fade,
+    { duration: 220, ...config }.duration,
+  ).then(() => {});
 }
 
 export function getVisibilityStatus(): Promise<VisibilityStatus> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,11 @@ const NativeModule: {
   getVisibilityStatus: () => Promise<VisibilityStatus>;
 } = NativeModules.RNBootSplash;
 
+const DEFAULT_DURATION = 220;
+
 export function hide(config: Config = {}): Promise<void> {
-  return NativeModule.hide(
-    { fade: false, ...config }.fade,
-    { duration: 220, ...config }.duration,
-  ).then(() => {});
+  const { fade = false, duration = DEFAULT_DURATION } = config;
+  return NativeModule.hide(fade, Math.max(duration, DEFAULT_DURATION)).then(() => {});
 }
 
 export function getVisibilityStatus(): Promise<VisibilityStatus> {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
This feature implements a custom duration for the splash screen fade out.
The parameter is optional, with the default being 220ms, as it was already before, making it backwards compatible without any changes for the current consumers.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Android emulator & iOS simulator is enough.


### What are the steps to test it (after prerequisites)?
```import * as React from "react";
import {
  View,
} from "react-native";
import * as BootSplash from "react-native-bootsplash";


export const App = () => {

  React.useEffect(() => {
     BootSplash.hide({fade:true, duration: 2500}); // Edit duration
  }, []);

  return (
    <View />)
};
```

## Compatibility

| OS      | Implemented |
| -------- | :---------: |
| iOS        |     ✅          |
| Android |    ✅           |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)

The current example project isn't "visually" compatible with this feature, as the logo is hidden from JS.