### PR TITLE
Add setup info to prevent possible crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ dependencies {
     android:roundIcon="@mipmap/ic_launcher_round"
     android:allowBackup="false"
     android:theme="@style/BootTheme"> <!-- Replace @style/AppTheme with @style/BootTheme -->
+    <!-- if you have other activities apart from .MainActivity, test the features associated to them, because you might need to set `android:theme="@style/AppTheme"` for these activities -->
     <!-- … -->
   </application>
 </manifest>


### PR DESCRIPTION
You might have some activities in your project that need a theme that is descendant of the Theme.AppCompat theme. When installing react-native-bootsplash, you'll need to specify the theme for these activities, otherwise it will take the theme @style/BootTheme which is not a descendant of Theme.AppCompat and you'll get a crash `Caused by java.lang.IllegalStateException: You need to use a Theme.AppCompat theme (or descendant) with this activity.`. This happens for example with the Google Cast SDK.
