### PR TITLE
feat: Adds conditional assets generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Options:
   --logo-width <width>        logo width at @1x (in dp - we recommend approximately ~100) (default: 100)
   --assets-path [path]        path to your static assets directory (useful to require the logo file in JS)
   --flavor <flavor>           [android only] flavor build variant (outputs in an android resource directory other than "main")
+  --android-only              generate icons for Android only (useful if you use a custom iOS launch screen)
+  --ios-only                  generate icons for iOS only (useful if you use a custom Android launch screen)
   -h, --help                  output usage information
 ```
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ Options:
   --logo-width <width>        logo width at @1x (in dp - we recommend approximately ~100) (default: 100)
   --assets-path [path]        path to your static assets directory (useful to require the logo file in JS)
   --flavor <flavor>           [android only] flavor build variant (outputs in an android resource directory other than "main")
-  --android-only              generate icons for Android only (useful if you use a custom iOS launch screen)
-  --ios-only                  generate icons for iOS only (useful if you use a custom Android launch screen)
+  --platforms [platforms]     platforms to generate assets for (comma separated) (default: "android,ios")
   -h, --help                  output usage information
 ```
 
@@ -140,7 +139,8 @@ yarn react-native generate-bootsplash assets/bootsplash_logo_original.png \
   --background-color=F5FCFF \
   --logo-width=100 \
   --assets-path=assets \
-  --flavor=main
+  --flavor=main \
+  --platforms=android,ios
 ```
 
 ![](https://raw.githubusercontent.com/zoontek/react-native-bootsplash/master/docs/cli_tool.png?raw=true)

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -32,19 +32,29 @@ module.exports = {
             '[android only] flavor build variant (outputs in an android resource directory other than "main")',
           default: "main",
         },
+        {
+          name: "--android-only",
+          description:
+            "generate icons for Android only (useful if you use a custom iOS launch screen)",
+        },
+                {
+          name: "--ios-only",
+          description:
+            "generate icons for iOS only (useful if you use a custom Android launch screen)",
+        },
       ],
       func: (
         [logoPath],
         { project: { android, ios } },
-        { backgroundColor, logoWidth, assetsPath, flavor },
+        { backgroundColor, logoWidth, assetsPath, flavor, androidOnly, iosOnly },
       ) => {
         const workingPath =
           process.env.INIT_CWD || process.env.PWD || process.cwd();
 
         return generate({
-          android,
+          android: android && !iosOnly ? android : null,
 
-          ios: ios
+          ios: ios && !androidOnly
             ? {
                 ...ios,
                 // Fix to support previous CLI versions

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -33,28 +33,27 @@ module.exports = {
           default: "main",
         },
         {
-          name: "--android-only",
-          description:
-            "generate icons for Android only (useful if you use a custom iOS launch screen)",
-        },
-                {
-          name: "--ios-only",
-          description:
-            "generate icons for iOS only (useful if you use a custom Android launch screen)",
-        },
+          name: '--platforms [platforms]',
+          description: 'platforms to generate the splash screen for (android, ios)',
+          default: 'android,ios',
+          parse: (value) => value.split(','),
+        }
       ],
       func: (
         [logoPath],
         { project: { android, ios } },
-        { backgroundColor, logoWidth, assetsPath, flavor, androidOnly, iosOnly },
+        { backgroundColor, logoWidth, assetsPath, flavor, platforms },
       ) => {
         const workingPath =
           process.env.INIT_CWD || process.env.PWD || process.cwd();
 
-        return generate({
-          android: android && !iosOnly ? android : null,
+        const iosOnly = platforms.includes('ios');
+        const androidOnly = platforms.includes('android');
 
-          ios: ios && !androidOnly
+        return generate({
+          android: android && androidOnly ? android : null,
+
+          ios: ios && iosOnly
             ? {
                 ...ios,
                 // Fix to support previous CLI versions


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Add functionality to generate assets for Android and iOS separately. It's useful when an app has 2 different splash screens for each platform or is developed only for iOS or Android. It impacts CLI script options.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What is the feature? (if applicable)


Add 2 flags to the script for conditional assets generation if assets need to be generated only for one of the platforms.

* What areas of the library does it impact?
-->


### What's required for testing (prerequisites)?
- yarn install
- run CLI script inside example folder and try to generate assets for iOS or Android separately.

### What are the steps to test it (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
