### PR TITLE
fix(android): android gradle plugin 8 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,9 @@ android {
 
     if (project.android.hasProperty("namespace")) {
         namespace "com.zoontek.rnbootsplash"
+        buildFeatures {
+            buildConfig true
+        }
     }
     defaultConfig {
         buildConfigField("boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString())


### PR DESCRIPTION

# Summary

Hey @zoontek 👋  - for AGP8+, if you use build config you have to opt-in to it now, it is turned off by default

So AGP8+ support for this module needs more than just the namespace, it also needs a little build.gradle tweak to enable build config


It is similar to changes I needed to do as react-native-firebase maintainer --> https://github.com/invertase/react-native-firebase/commit/b52d0ce6723c077190618641ce0f33ced9fd4090

## Test Plan

With apologies, you have to alter an app that integrates this module to use android gradle plugin 8, it's difficult to do that in repos I'm proposing these changes in because bumping to android gradle plugin 8 requries a large amount of transitive dependency changes in CI - the example app here is still depending on AGP7+ so doesn't show it

I have integrated this in an app and tested it, and done similar work as maintainer of react-native-firebase, react-native-netinfo and react-native-device-info, and I'm now pushing these out to the repos

Cheers
