### PR TITLE
Fixes #552; de-initialize RNBootSplash on activity destroy

### DIFF
--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModuleImpl.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModuleImpl.java
@@ -136,6 +136,14 @@ public class RNBootSplashModuleImpl {
     });
   }
 
+  protected static void deInit() {
+    mThemeResId = -1;
+    mStatus = Status.HIDDEN;
+    mInitialDialog = null;
+    mFadeOutDialog = null;
+    clearPromiseQueue();
+  }
+
   private static void clearPromiseQueue() {
     while (!mPromiseQueue.isEmpty()) {
       Promise promise = mPromiseQueue.shift();

--- a/android/src/newarch/com/zoontek/rnbootsplash/RNBootSplashModule.java
+++ b/android/src/newarch/com/zoontek/rnbootsplash/RNBootSplashModule.java
@@ -2,6 +2,7 @@ package com.zoontek.rnbootsplash;
 
 import androidx.annotation.NonNull;
 
+import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.module.annotations.ReactModule;
@@ -9,10 +10,11 @@ import com.facebook.react.module.annotations.ReactModule;
 import java.util.Map;
 
 @ReactModule(name = RNBootSplashModuleImpl.NAME)
-public class RNBootSplashModule extends NativeRNBootSplashSpec {
+public class RNBootSplashModule extends NativeRNBootSplashSpec implements LifecycleEventListener {
 
   public RNBootSplashModule(ReactApplicationContext reactContext) {
     super(reactContext);
+    reactContext.addLifecycleEventListener(this);
   }
 
   @Override
@@ -34,5 +36,18 @@ public class RNBootSplashModule extends NativeRNBootSplashSpec {
   @Override
   public void isVisible(Promise promise) {
     RNBootSplashModuleImpl.isVisible(promise);
+  }
+
+  @Override
+  public void onHostResume() {
+  }
+
+  @Override
+  public void onHostPause() {
+  }
+
+  @Override
+  public void onHostDestroy() {
+    RNBootSplashModuleImpl.deInit();
   }
 }

--- a/android/src/oldarch/com/zoontek/rnbootsplash/RNBootSplashModule.java
+++ b/android/src/oldarch/com/zoontek/rnbootsplash/RNBootSplashModule.java
@@ -3,6 +3,7 @@ package com.zoontek.rnbootsplash;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -12,10 +13,11 @@ import com.facebook.react.module.annotations.ReactModule;
 import java.util.Map;
 
 @ReactModule(name = RNBootSplashModuleImpl.NAME)
-public class RNBootSplashModule extends ReactContextBaseJavaModule {
+public class RNBootSplashModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
 
   public RNBootSplashModule(ReactApplicationContext reactContext) {
     super(reactContext);
+    reactContext.addLifecycleEventListener(this);
   }
 
   @NonNull
@@ -38,5 +40,18 @@ public class RNBootSplashModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void isVisible(Promise promise) {
     RNBootSplashModuleImpl.isVisible(promise);
+  }
+
+  @Override
+  public void onHostResume() {
+  }
+
+  @Override
+  public void onHostPause() {
+  }
+
+  @Override
+  public void onHostDestroy() {
+    RNBootSplashModuleImpl.deInit();
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Fix for #552, have exposed a `deInit` method which needs to be called when the `onDestroy` of activity is called. 

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
There is no larger impact, have only reset a few variables upon activity destroy which are recreated when init is called again.

### What's required for testing (prerequisites)?
Sample repro - https://github.com/Protino/splash-flash-repro

### What are the steps to test it (after prerequisites)?
Add this patch to the repro, re-run the scenario, and verify splash screen doesn't flash

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅  (Fix NA)   |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I added a sample use of the API in the example project (`example/App.tsx`)
