### PR TITLE
Fix Info.plist

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -656,7 +656,7 @@ export const generate = async ({
       unknown
     >;
 
-    infoPlist["UILaunchStoryboardName"] = "BootSplash.storyboard";
+    infoPlist["UILaunchStoryboardName"] = "BootSplash";
 
     const formatted = formatXml(plist.build(infoPlist), {
       collapseContent: true,


### PR DESCRIPTION
Removed the .storyboard extension from the UILaunchStoryboardName value in Info.plist

If the .storyboard extension is present and iPad multitasking is enabled, App Store Connect asset validation fails with the message "Because your app supports Multitasking on iPad, you need to include the BootSplash.storyboard launch storyboard file"

The extension-less value for UILaunchStoryboardName worked fine for me in v4 of this library, but v5 insisted on adding it back to my Info.plist which broke asset validation. This change drops the extension again and fixes asset validation (confirmed with XCode 15.2).

SO indicates I'm not the only one with this problem/fix: https://stackoverflow.com/questions/32557783/invalid-bundle-error-requires-launch-storyboard/74744786#74744786

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to test it (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
