### PR TITLE
Ability to specify whether the project is bare or expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Options:
   --dark-background <string>  [dark mode] Background color (in hexadecimal format)
   --dark-logo <string>        [dark mode] Logo file path (PNG or SVG)
   --dark-brand <string>       [dark mode] Brand file path (PNG or SVG)
+  --expo <boolean>            Generate assets for expo or bare project (default true)
   -h, --help                  display help for command
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Usage: react-native generate-bootsplash [options] <logo>
 Generate a launch screen using a logo file path (PNG or SVG)
 
 Options:
+  --project-type <string>     Project type ("detect", "bare" or "expo") (default: "detect")
   --platforms <list>          Platforms to generate for, separated by a comma (default: "android,ios,web")
   --background <string>       Background color (in hexadecimal format) (default: "#fff")
   --logo-width <number>       Logo width at @1x (in dp - we recommend approximately ~100) (default: 100)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Options:
   --dark-background <string>  [dark mode] Background color (in hexadecimal format)
   --dark-logo <string>        [dark mode] Logo file path (PNG or SVG)
   --dark-brand <string>       [dark mode] Brand file path (PNG or SVG)
-  --expo <boolean>            Generate assets for expo or bare project (default true)
   -h, --help                  display help for command
 ```
 

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -75,6 +75,12 @@ const generateBootSplash = {
       name: "--dark-brand <string>",
       description: "[dark mode] Brand file path (PNG or SVG)",
     },
+    {
+      name: "--expo <boolean>",
+      description: "Generate assets for expo or bare project",
+      default: true,
+      parse: (value) => value === "true",
+    }
   ],
   func: ([logo], { project: { android, ios } }, args) => {
     const { generate } = require("./dist/commonjs/generate");

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,10 +1,20 @@
 const platforms = ["android", "ios", "web"];
+const projectTypes = ["detect", "bare", "expo"];
 
 /** @type {import("@react-native-community/cli-types").Command} */
 const generateBootSplash = {
   name: "generate-bootsplash <logo>",
   description: "Generate a launch screen using a logo file path (PNG or SVG)",
   options: [
+    {
+      name: "--project-type <string>",
+      description: 'Project type ("detect", "bare" or "expo")',
+      default: "detect",
+      parse: (value) => {
+        const type = value.toLowerCase();
+        return projectTypes.includes(type) ? type : "detect";
+      },
+    },
     {
       name: "--platforms <list>",
       description: "Platforms to generate for, separated by a comma",
@@ -75,12 +85,6 @@ const generateBootSplash = {
       name: "--dark-brand <string>",
       description: "[dark mode] Brand file path (PNG or SVG)",
     },
-    {
-      name: "--expo <boolean>",
-      description: "Generate assets for expo or bare project",
-      default: true,
-      parse: (value) => value === "true",
-    }
   ],
   func: ([logo], { project: { android, ios } }, args) => {
     const { generate } = require("./dist/commonjs/generate");

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -26,6 +26,7 @@ import { Manifest } from ".";
 const workingPath = process.env.INIT_CWD ?? process.env.PWD ?? process.cwd();
 const projectRoot = findProjectRoot(workingPath);
 
+type ProjectType = "detect" | "bare" | "expo";
 type Platforms = ("android" | "ios" | "web")[];
 
 export type RGBColor = {
@@ -584,17 +585,18 @@ const requireAddon = ():
 export const generate = async ({
   android,
   ios,
+  projectType,
   platforms,
   html,
   flavor,
   licenseKey,
-  expo = true,
   ...args
 }: {
   android?: AndroidProjectConfig;
   ios?: IOSProjectConfig;
 
   logo: string;
+  projectType: ProjectType;
   platforms: Platforms;
   background: string;
   logoWidth: number;
@@ -608,13 +610,11 @@ export const generate = async ({
   darkBackground?: string;
   darkLogo?: string;
   darkBrand?: string;
-  expo?: boolean;
 }) => {
-  let isExpo = false;
-
-  if (expo) {
-    isExpo = getExpoConfig(workingPath).isExpo;
-  }
+  const isExpo =
+    projectType === "detect" || projectType === "expo"
+      ? getExpoConfig(workingPath).isExpo
+      : false;
 
   if (semver.lt(process.versions.node, "18.0.0")) {
     log.error("Requires Node 18 (or higher)");

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -588,6 +588,7 @@ export const generate = async ({
   html,
   flavor,
   licenseKey,
+  expo = true,
   ...args
 }: {
   android?: AndroidProjectConfig;
@@ -607,8 +608,13 @@ export const generate = async ({
   darkBackground?: string;
   darkLogo?: string;
   darkBrand?: string;
+  expo?: boolean;
 }) => {
-  const { isExpo } = getExpoConfig(workingPath);
+  let isExpo = false;
+
+  if (expo) {
+    isExpo = getExpoConfig(workingPath).isExpo;
+  }
 
   if (semver.lt(process.versions.node, "18.0.0")) {
     log.error("Requires Node 18 (or higher)");


### PR DESCRIPTION
Realization of the choice of whether the project is bare or expo. 

# Summary

Added new cli options to specify whether the project is an expo or bare with expo modules

See request feature issue https://github.com/zoontek/react-native-bootsplash/issues/597

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

* create app using `npx create-expo-app@latest --template bare-minimum`
* install `react-native-bootsplash`
* run `react-native generate-bootsplash  icon --expo=false`

### What are the steps to test it (after prerequisites)?

#### bare project (with expo modules)

run `react-native generate-bootsplash  icon --expo=false`

Expected result:

```
🤖  Android
    android/app/main/res/drawable-mdpi/bootsplash_logo.png (288x288)
    android/app/main/res/drawable-hdpi/bootsplash_logo.png (432x432)
    android/app/main/res/drawable-xhdpi/bootsplash_logo.png (576x576)
    android/app/main/res/drawable-xxhdpi/bootsplash_logo.png (864x864)
    android/app/main/res/drawable-xxxhdpi/bootsplash_logo.png (1152x1152)
    android/app/main/AndroidManifest.xml
    android/app/main/res/values/colors.xml
    android/app/main/res/values/styles.xml

🍏  iOS
    ios/YourApp/BootSplash.storyboard
    ios/YourApp/Colors.xcassets/BootSplashBackground-<hash>.colorset/Contents.json
    ios/YourApp/Images.xcassets/BootSplashLogo-<hash>.imageset/Contents.json
    ios/YourApp/Images.xcassets/BootSplashLogo-<hash>.imageset/logo-<hash>.png
    ios/YourApp/Images.xcassets/BootSplashLogo-<hash>.imageset/logo-<hash>@2x.png
    ios/YourApp/Images.xcassets/BootSplashLogo-<hash>.imageset/logo-<hash>@3x.png
    ios/YourApp/Info.plist
    ios/YourApp.xcodeproj/project.pbxproj
```

#### expo

run `react-native generate-bootsplash  icon `

Expected result:
```
🤖  Android
    assets/bootsplash/android/drawable-mdpi/bootsplash_logo.png (288x288)
    assets/bootsplash/android/drawable-hdpi/bootsplash_logo.png (432x432)
    assets/bootsplash/android/drawable-xhdpi/bootsplash_logo.png (576x576)
    assets/bootsplash/android/drawable-xxhdpi/bootsplash_logo.png (864x864)
    assets/bootsplash/android/drawable-xxxhdpi/bootsplash_logo.png (1152x1152)

🍏  iOS
    assets/bootsplash/ios/BootSplash.storyboard
    assets/bootsplash/ios/Colors.xcassets/BootSplashBackground-4f7342.colorset/Contents.json
    assets/bootsplash/ios/Images.xcassets/BootSplashLogo-4f7342.imageset/Contents.json
    assets/bootsplash/ios/Images.xcassets/BootSplashLogo-4f7342.imageset/logo-4f7342.png (100x100)
    assets/bootsplash/ios/Images.xcassets/BootSplashLogo-4f7342.imageset/logo-4f7342@2x.png (200x200)
    assets/bootsplash/ios/Images.xcassets/BootSplashLogo-4f7342.imageset/logo-4f7342@3x.png (300x300)

```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this
- [x] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
