### PR TITLE
Solved the issue of small splash screen in OneUI4

### DIFF
--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashDialog.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashDialog.java
@@ -108,10 +108,6 @@ public class RNBootSplashDialog extends Dialog {
       window.setWindowAnimations(mFade
         ? R.style.BootSplashFadeOutAnimation
         : R.style.BootSplashNoAnimation);
-
-      if (RNBootSplashModuleImpl.isSamsungOneUI4()) {
-        window.setBackgroundDrawableResource(R.drawable.compat_splash_screen_oneui_4);
-      }
     }
 
     super.onCreate(savedInstanceState);

--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModuleImpl.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModuleImpl.java
@@ -234,13 +234,13 @@ public class RNBootSplashModuleImpl {
   }
 
   // From https://stackoverflow.com/a/61062773
-  public static boolean isSamsungOneUI4() {
+  public static boolean isSamsungOneUIAbove4() {
     String name = "SEM_PLATFORM_INT";
 
     try {
       Field field = Build.VERSION.class.getDeclaredField(name);
       int version = (field.getInt(null) - 90000) / 10000;
-      return version == 4;
+      return version >= 4;
     } catch (Exception ignored) {
       return false;
     }
@@ -284,7 +284,7 @@ public class RNBootSplashModuleImpl {
       : 0;
 
     constants.put("darkModeEnabled", uiMode == Configuration.UI_MODE_NIGHT_YES);
-    constants.put("logoSizeRatio", isSamsungOneUI4() ? 0.5 : 1);
+    constants.put("logoSizeRatio", isSamsungOneUIAbove4() ? 0.5 : 1);
     constants.put("navigationBarHeight", navigationBarHeight);
     constants.put("statusBarHeight", statusBarHeight);
 

--- a/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModuleImpl.java
+++ b/android/src/main/java/com/zoontek/rnbootsplash/RNBootSplashModuleImpl.java
@@ -233,19 +233,6 @@ public class RNBootSplashModuleImpl {
     });
   }
 
-  // From https://stackoverflow.com/a/61062773
-  public static boolean isSamsungOneUIAbove4() {
-    String name = "SEM_PLATFORM_INT";
-
-    try {
-      Field field = Build.VERSION.class.getDeclaredField(name);
-      int version = (field.getInt(null) - 90000) / 10000;
-      return version >= 4;
-    } catch (Exception ignored) {
-      return false;
-    }
-  }
-
   protected static void onHostDestroy() {
     mStatus = Status.HIDDEN;
     mThemeResId = -1;
@@ -284,7 +271,7 @@ public class RNBootSplashModuleImpl {
       : 0;
 
     constants.put("darkModeEnabled", uiMode == Configuration.UI_MODE_NIGHT_YES);
-    constants.put("logoSizeRatio", isSamsungOneUIAbove4() ? 0.5 : 1);
+    constants.put("logoSizeRatio", 1);
     constants.put("navigationBarHeight", navigationBarHeight);
     constants.put("statusBarHeight", statusBarHeight);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Solved the issue of small splash screen in oneui4. 
With this code, the image size is displayed the same as the same image file in One UI 4, 5, 6 and later versions.

## Test Plan

To test this, install the library and run it on a device with One UI 4. This will verify that the issue has been resolved.

### What's required for testing (prerequisites)?

Samsung one ui above 4 real phone.

### What are the steps to test it (after prerequisites)?

Install libraray and run it.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
