### PR TITLE
Running RCTKeyWindow on main thread

### DIFF
--- a/ios/RNBootSplash.mm
+++ b/ios/RNBootSplash.mm
@@ -133,10 +133,10 @@ RCT_EXPORT_MODULE();
 }
 
 - (NSDictionary *)constantsToExport {
-  UIWindow *window = RCTKeyWindow();
   __block bool darkModeEnabled = false;
 
   RCTUnsafeExecuteOnMainQueueSync(^{
+    UIWindow *window = RCTKeyWindow();
     darkModeEnabled = window != nil && window.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark;
   });
 


### PR DESCRIPTION
# Summary

Closes https://github.com/zoontek/react-native-bootsplash/issues/619

## Test Plan

Run example iOS app in xcode with Main thread breakpoint enabled.

Expected Behavior:
No breakpoint should be thrown.

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
