### PR TITLE
Expose constants, so one can use it for ones own animations.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,10 @@ export function isVisible(): Promise<boolean> {
   return NativeModule.isVisible();
 }
 
+export function getConstants() {
+  return NativeModule.getConstants();
+}
+
 export function useHideAnimation(config: UseHideAnimationConfig) {
   const {
     manifest,
@@ -265,4 +269,5 @@ export default {
   hide,
   isVisible,
   useHideAnimation,
+  getConstants,
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

I am currently implementing my own animation using Reanimated 3 instead of react native's default animation. And currently there isn't an easy way to get the correct positions for the logo or brand text when on android, as some devices may have a nav bar or not. And as the library already has its own native modules to get these constants, it would be very helpful if they could also be used in ones code.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
