### PR TITLE
fix: call super in customizeRootView

### DIFF
--- a/src/expo.ts
+++ b/src/expo.ts
@@ -286,6 +286,7 @@ const withAppDelegate: ExpoPlugin = (config) =>
       anchor: /@end/,
       newSrc: dedent`
         - (void)customizeRootView:(RCTRootView *)rootView {
+          [super customizeRootView:rootView];
           [RNBootSplash initWithStoryboard:@"BootSplash" rootView:rootView];
         }
       `,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Calling super will allow expo modules to work properly when using customizeRootView in expoAppDelegateSubscribers

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅   |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
