### PR TITLE
Make sharp an optional dependency to avoid LGPL-3.0 license conflicts

### DIFF
--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -5904,20 +5904,6 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
-sharp@^0.32.6:
-  version "0.32.6"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.32.6.tgz#6ad30c0b7cd910df65d5f355f774aa4fce45732a"
-  integrity sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==
-  dependencies:
-    color "^4.2.3"
-    detect-libc "^2.0.2"
-    node-addon-api "^6.1.0"
-    prebuild-install "^7.1.1"
-    semver "^7.5.4"
-    simple-get "^4.0.1"
-    tar-fs "^3.0.4"
-    tunnel-agent "^0.6.0"
-
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"

--- a/package.json
+++ b/package.json
@@ -80,9 +80,11 @@
     "picocolors": "^1.1.1",
     "prettier": "^3.5.3",
     "react-native-is-edge-to-edge": "^1.1.7",
-    "sharp": "^0.32.6",
     "ts-dedent": "^2.2.0",
     "xml-formatter": "^3.6.5"
+  },
+  "optionalDependencies": {
+    "sharp": "^0.32.6"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4781,20 +4781,6 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-sharp@^0.32.6:
-  version "0.32.6"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.32.6.tgz#6ad30c0b7cd910df65d5f355f774aa4fce45732a"
-  integrity sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==
-  dependencies:
-    color "^4.2.3"
-    detect-libc "^2.0.2"
-    node-addon-api "^6.1.0"
-    prebuild-install "^7.1.1"
-    semver "^7.5.4"
-    simple-get "^4.0.1"
-    tar-fs "^3.0.4"
-    tunnel-agent "^0.6.0"
-
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"


### PR DESCRIPTION
This PR makes the sharp library an optional dependency to prevent it from being included in the dependency tree by default. The motivation behind this change is to avoid introducing a transitive dependency with the LGPL-3.0-or-later license, which may conflict with the MIT license of this project and with the legal requirements of consumers using react-native-bootsplash.

Although sharp is not used directly in runtime, its presence in the dependency tree can trigger license concerns during audits, as reported in [this issue](https://github.com/vercel/next.js/issues/72406) and confirmed in [Sharp’s dependency report](https://deps.dev/npm/sharp/0.33.3/dependencies?filter=license%3A%22LGPL-3.0-or-later%22).

By marking it as optional, consumers who need sharp for asset generation can still install it manually, while others avoid inheriting the LGPL license risk.

Let me know if you’d like me to make further adjustments. Thanks!