### PR TITLE
fix: customize root view override signature in config plugin

### DIFF
--- a/src/expo.ts
+++ b/src/expo.ts
@@ -305,7 +305,7 @@ const withAppDelegate: Expo.ConfigPlugin<Props> = (config) =>
           offset: 1,
           anchor: /class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {/,
           newSrc: dedent`
-            public override func customize(_ rootView: RCTRootView) {
+            public override func customize(_ rootView: UIView) {
               super.customize(rootView)
               RNBootSplash.initWithStoryboard("BootSplash", rootView: rootView)
             }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

While upgrading to expo SDK 53 using static libraries (`expo-build-properties` with `ios.useFrameworks: "static"`), we ran into the following error in the `AppDelegate.swift` when building: 

<img width="721" alt="Screenshot 2025-04-28 at 15 41 59" src="https://github.com/user-attachments/assets/878b9545-1ffc-45f9-9ebf-9d8320ad0e0c" />

This PR fixes this issue. 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

It can be reproduced on the react-conf-app branch upgrading to SDK 53.

Update `app.config.js` on [this branch](https://github.com/expo/react-conf-app/tree/%40kadikraman/upgrade-sdk-53) to add the following options to the `expo-build-properties` config plugin: 
```
[
  "expo-build-properties",
  {
    ios: {
      useFrameworks: "static",
    },
  },
],
```

iOS build will fail 

### What are the steps to test it (after prerequisites)?

Applying the change in this PR (changing `customize` signature from `public override func customize(_ rootView: RCTRootView)` to `public override func customize(_ rootView: UIView)` in the `AppDelegate` will let you build

I've also tested with dynamic libraries (no option passed to `expo-build-properties`) and this fix introduced no regression.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
