### PR TITLE
docs: Add missing Arguments section to CLI help in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Usage: react-native-bootsplash generate [options] <logo>
 
 Generate a launch screen using a logo file path (PNG or SVG)
 
+Arguments:
+  logo                        Logo file path (PNG or SVG)
+
 Options:
   --project-type <string>     Project type ("detect", "bare" or "expo") (default: "detect")
   --platforms <list>          Platforms to generate for, separated by a comma (default: "android,ios,web")


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Added the missing Arguments section to the CLI help documentation in README.md to match the actual command output from `yarn react-native-bootsplash generate --help`.

The README was missing the Arguments section that shows the required `logo` parameter, which could confuse users trying to understand the command structure.

<img width="880" height="558" alt="image" src="https://github.com/user-attachments/assets/3f63245c-dd49-4360-8555-e85a5e3368c4" />


## Test Plan

### What's required for testing (prerequisites)?

### What are the steps to test it (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    N\A     |
| Android |    N\A     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
