### PR TITLE
feat(tvOS): support tvOS storyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Arguments:
 
 Options:
   --platforms <list>          Platforms to generate for, separated by a comma (default: "android,ios,web")
-  --is-tv                     Build for TV (setting EXPO_TV to "true" or "1" will override this value) (default: false)
+  --is-tv                     Generate for TV (default: false)
   --background <string>       Background color (in hexadecimal format) (default: "#fff")
   --logo-width <number>       Logo width at @1x (in dp - we recommend approximately ~100) (default: 100)
   --assets-output <string>    Assets output directory path (default: "assets/bootsplash")

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Arguments:
 
 Options:
   --platforms <list>          Platforms to generate for, separated by a comma (default: "android,ios,web")
+  --is-tv                     Build for TV (setting EXPO_TV to "true" or "1" will override this value) (default: false)
   --background <string>       Background color (in hexadecimal format) (default: "#fff")
   --logo-width <number>       Logo width at @1x (in dp - we recommend approximately ~100) (default: 100)
   --assets-output <string>    Assets output directory path (default: "assets/bootsplash")

--- a/cli.js
+++ b/cli.js
@@ -20,6 +20,11 @@ program
     validPlatforms.join(","),
   )
   .option(
+    "--is-tv",
+    'Build for TV (setting EXPO_TV to "true" or "1" will override this value)',
+    false,
+  )
+  .option(
     "--background <string>",
     "Background color (in hexadecimal format)",
     "#fff",

--- a/cli.js
+++ b/cli.js
@@ -19,11 +19,7 @@ program
     "Platforms to generate for, separated by a comma",
     validPlatforms.join(","),
   )
-  .option(
-    "--is-tv",
-    'Build for TV (setting EXPO_TV to "true" or "1" will override this value)',
-    false,
-  )
+  .option("--is-tv", "Generate for TV", false)
   .option(
     "--background <string>",
     "Background color (in hexadecimal format)",

--- a/package.json
+++ b/package.json
@@ -115,9 +115,11 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
+    "@types/getenv": "^1.0.3",
     "@types/node": "^20.19.39",
     "@types/react": "^19.2.0",
     "@types/semver": "^7.7.1",
+    "getenv": "^2.0.0",
     "oxlint": "^1.59.0",
     "prettier-plugin-organize-imports": "^4.3.0",
     "react": "19.2.3",

--- a/src/extras/expo.ts
+++ b/src/extras/expo.ts
@@ -3,6 +3,7 @@ import { assignColorValue } from "@expo/config-plugins/build/android/Colors";
 import { addImports } from "@expo/config-plugins/build/android/codeMod";
 import { mergeContents } from "@expo/config-plugins/build/utils/generateCode";
 import childProcess from "child_process";
+import { boolish } from "getenv";
 import path from "path";
 import semver from "semver";
 import { dedent } from "ts-dedent";
@@ -204,9 +205,10 @@ const withIOSAssets: ConfigPlugin = (expoConfig, rawProps) =>
       const props = await transformProps(projectRoot, rawProps);
       const addon = requireAddon(props);
       const iosOutputPath = path.resolve(platformProjectRoot, projectName);
+      const isTv = boolish("EXPO_TV", false);
 
-      await writeIOSAssets({ iosOutputPath, props });
-      await addon?.writeIOSAssets({ iosOutputPath, props });
+      await writeIOSAssets({ iosOutputPath, props, isTv });
+      await addon?.writeIOSAssets({ iosOutputPath, props, isTv });
 
       return config;
     },

--- a/src/extras/generate.ts
+++ b/src/extras/generate.ts
@@ -171,7 +171,7 @@ export const generate = async ({
   ...rawProps
 }: {
   platforms: Array<"android" | "ios" | "web">;
-  isTv?: boolean;
+  isTv: boolean;
   html: string;
   flavor: string;
   plist?: string;

--- a/src/extras/generate.ts
+++ b/src/extras/generate.ts
@@ -164,12 +164,14 @@ const getInfoPlistPath = ({
 
 export const generate = async ({
   platforms,
+  isTv,
   html,
   flavor,
   plist,
   ...rawProps
 }: {
   platforms: Array<"android" | "ios" | "web">;
+  isTv?: boolean;
   html: string;
   flavor: string;
   plist?: string;
@@ -326,7 +328,7 @@ export const generate = async ({
   }
 
   if (iosOutputPath != null) {
-    await writeIOSAssets({ iosOutputPath, props });
+    await writeIOSAssets({ iosOutputPath, props, isTv });
 
     const pbxprojectPath = Expo.IOSConfig.Paths.getPBXProjectPath(projectRoot);
 

--- a/src/extras/utils.ts
+++ b/src/extras/utils.ts
@@ -508,7 +508,7 @@ export const writeAndroidAssets = async ({
   );
 };
 
-const getStoryboard = (props: Props) => {
+const getStoryboard = (props: Props, isTV?: boolean) => {
   const { background, logo, fileNameSuffix } = props;
 
   const { R, G, B } = background.rgb;
@@ -517,10 +517,10 @@ const getStoryboard = (props: Props) => {
 
   return dedent`
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="${!isTV ? "com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" : "com.apple.InterfaceBuilder.AppleTV.Storyboard"}" version="3.0" toolsVersion="21701" targetRuntime="${!isTV ? "iOS.CocoaTouch" : "AppleTV"}" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
+        <deployment identifier="${!isTV ? "iOS" : "tvOS"}"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -568,9 +568,11 @@ const getStoryboard = (props: Props) => {
 export const writeIOSAssets = async ({
   iosOutputPath,
   props,
+  isTv,
 }: {
   iosOutputPath: string;
   props: Props;
+  isTv?: boolean;
 }) => {
   const { background, logo, fileNameSuffix } = props;
 
@@ -594,7 +596,10 @@ export const writeIOSAssets = async ({
 
   const storyboardPath = path.resolve(iosOutputPath, "BootSplash.storyboard");
 
-  await writeXmlLike(storyboardPath, getStoryboard(props), {
+  const isTV =
+    process.env.EXPO_TV === "1" || process.env.EXPO_TV === "true" || isTv;
+
+  await writeXmlLike(storyboardPath, getStoryboard(props, isTV), {
     formatter: "xmlFormatter",
     whiteSpaceAtEndOfSelfclosingTag: false,
   });

--- a/src/extras/utils.ts
+++ b/src/extras/utils.ts
@@ -508,7 +508,7 @@ export const writeAndroidAssets = async ({
   );
 };
 
-const getStoryboard = (props: Props, isTV?: boolean) => {
+const getStoryboard = (props: Props, isTv: boolean) => {
   const { background, logo, fileNameSuffix } = props;
 
   const { R, G, B } = background.rgb;
@@ -517,10 +517,10 @@ const getStoryboard = (props: Props, isTV?: boolean) => {
 
   return dedent`
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="${!isTV ? "com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" : "com.apple.InterfaceBuilder.AppleTV.Storyboard"}" version="3.0" toolsVersion="21701" targetRuntime="${!isTV ? "iOS.CocoaTouch" : "AppleTV"}" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="${!isTv ? "com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" : "com.apple.InterfaceBuilder.AppleTV.Storyboard"}" version="3.0" toolsVersion="21701" targetRuntime="${!isTv ? "iOS.CocoaTouch" : "AppleTV"}" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="${!isTV ? "iOS" : "tvOS"}"/>
+        <deployment identifier="${!isTv ? "iOS" : "tvOS"}"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -572,7 +572,7 @@ export const writeIOSAssets = async ({
 }: {
   iosOutputPath: string;
   props: Props;
-  isTv?: boolean;
+  isTv: boolean;
 }) => {
   const { background, logo, fileNameSuffix } = props;
 
@@ -596,10 +596,7 @@ export const writeIOSAssets = async ({
 
   const storyboardPath = path.resolve(iosOutputPath, "BootSplash.storyboard");
 
-  const isTV =
-    process.env.EXPO_TV === "1" || process.env.EXPO_TV === "true" || isTv;
-
-  await writeXmlLike(storyboardPath, getStoryboard(props, isTV), {
+  await writeXmlLike(storyboardPath, getStoryboard(props, isTv), {
     formatter: "xmlFormatter",
     whiteSpaceAtEndOfSelfclosingTag: false,
   });
@@ -824,6 +821,7 @@ export const requireAddon = ({
       writeIOSAssets: (_: {
         iosOutputPath: string;
         props: Props;
+        isTv: boolean;
       }) => Promise<void>;
 
       writeWebAssets: (_: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,6 +1612,13 @@
   dependencies:
     "@babel/types" "^7.28.2"
 
+"@types/getenv@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/getenv/-/getenv-1.0.3.tgz#9fe071e4143f249309bbea99644ed139ded246ba"
+  integrity sha512-aCe60hc2U/xtdnGYbcZBFm6Xkm/MFuWqKMbhupcGt7DJ1QojADIXFKthtlgTwyXkEi6vr8lMXtOI218Ua9qx6w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.9.tgz#2a06bc0f68a20ab37b3e36aa238be6abdf49e8b4"


### PR DESCRIPTION
# Summary

While the podspec file already have tvOS target, it doesn’t supported yet due to different storyboard format.
```
iOS storyboards do not support target device type "tv".
```

When building for TV on expo, generic `SplashScreen.storyboard` will be replaced with tvOS-specific attributes by `@react-native-tvos/config-tv` expo plugin when set `EXPO_TV` env variable to 1 or true ([withTVSplashScreen.ts](https://github.com/react-native-tvos/config-tv/blob/main/packages/config-tv/src/withTVSplashScreen.ts)). But it will not replacing `BootSplash.storyboard`.

This PR introduces support for tvOS without relying on third-party config plugin, by generating storyboard based on `--is-tv` args (for cli), or `EXPO_TV` env variable (for expo), then it generates storyboard file based on that.

### Changes
- `cli.js`: add `--is-tv` args, which will be `isTv` in props.
- `generate.ts`: accept that `isTv` and pass to `writeIOSAssets`. (We pass it in specific `isTv`, not in `props` as it will not being used when using expo config plugin, it will not be in `BootSplashPluginConfig` type)
- `expo.ts`: detect `EXPO_TV` env variable and pass it to `writeIOSAssets`.
- `utils.ts`: the main changes
    - `writeIOSAssets`: accept `isTv` from `generate.ts` (from `--is-tv` args) and from `expo.ts` (from `EXPO_TV` env), and pass it to `getStoryboard`.
    - `getStoryboard`: accept `isTv` to conditionally generates the storyboard with `type="com.apple.InterfaceBuilder.AppleTV.Storyboard"`, `targetRuntime="AppleTV"`, `identifier="tvOS"` if `isTv` is true. ([reference](https://github.com/react-native-tvos/config-tv/blob/main/packages/config-tv/src/withTVSplashScreen.ts))
- ⚠️ Note that the addon also needed to be edited as same as the `utils.ts` changes. ⚠️

This doesn’t have any changes for Android TV, as it has the same format as Android.

> Note that the `@react-native-tvos/config-tv` detecting `EXPO_TV` env variable by `getenv`, so we match it to ensure consistency. [reference](https://github.com/react-native-tvos/config-tv/blob/main/packages/config-tv/src/utils/config.ts)

## Test Plan

### What's required for testing (prerequisites)?

- [`react-native-tvos`](https://github.com/react-native-tvos/react-native-tvos)
- If using expo, also use [`@react-native-tvos/config-tv`](https://github.com/react-native-tvos/config-tv) config plugin. [see expo guides](https://docs.expo.dev/guides/building-for-tv/)

### What are the steps to test it (after prerequisites)?

- For bare react-native: generate splash screen in cli with `--is-tv` args.
- For expo: add `@react-native-tvos/config-tv` to expo app.config, and run prebuild with `EXPO_TV=1`.
- See the generated `ios/[PROJECT_NAME]/BootSplash.storyboard` (or view it in Xcode, it will show as tvOS storyboard).


### Before
<img width="267" height="71" alt="Screenshot 2026-06-20 at 07 49 50" src="https://github.com/user-attachments/assets/f8cb15f8-62b8-4ce4-b1c8-fd85a9dd5f95" />
<img width="1087" height="185" alt="Screenshot 2026-06-20 at 06 44 14" src="https://github.com/user-attachments/assets/840582f0-ce18-4394-81a9-5cd5a6b12646" />
<img width="1490" height="1626" alt="Screenshot 2026-06-20 at 06 43 59" src="https://github.com/user-attachments/assets/5b29562b-64be-4d2b-bccf-7cdd1206dca5" />

### After
<img width="976" height="187" alt="Screenshot 2026-06-20 at 06 47 21" src="https://github.com/user-attachments/assets/dead5a56-d54c-4f8b-b09c-c07e52898190" />
<img width="1808" height="1636" alt="Screenshot 2026-06-20 at 06 42 49" src="https://github.com/user-attachments/assets/f9d07304-9746-4e95-8876-3e0162c546e4" />


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅ (add tvOS)     |
| Android |    ❌ (already supported)     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
